### PR TITLE
Defend --no-default-features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
           - # Default
           - --features=alloc
           - --all-features
+          - --no-default-features
 
         target:
           # There is no platform-specific code in webpki. Choose a handful of
@@ -141,6 +142,7 @@ jobs:
         exclude:
           - features: # Default
           - features: --features=alloc
+          - features: --no-default-features
           - features: --all-features
             mode: --release
           - features: --all-features
@@ -161,6 +163,12 @@ jobs:
             host_os: ubuntu-20.04
 
           - features: --features=alloc
+            target: x86_64-unknown-linux-gnu
+            mode: # debug
+            rust_channel: stable
+            host_os: ubuntu-20.04
+
+          - features: --no-default-features
             target: x86_64-unknown-linux-gnu
             mode: # debug
             rust_channel: stable

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -72,11 +72,12 @@ pub fn ed25519() {
 }
 
 #[test]
+#[cfg(feature = "alloc")]
 fn critical_extensions() {
     let root = include_bytes!("critical_extensions/root-cert.der");
     let ca = include_bytes!("critical_extensions/ca-cert.der");
 
-    let time = webpki::Time::try_from(std::time::SystemTime::now()).unwrap();
+    let time = webpki::Time::from_seconds_since_unix_epoch(1_670_779_098);
     let anchors = [webpki::TrustAnchor::try_from_cert_der(root).unwrap()];
     let anchors = webpki::TLSServerTrustAnchors(&anchors);
 


### PR DESCRIPTION
This was currently broken, since one of the tests required RSA ( = alloc feature) and real time (= std feature). The latter is a mistake, cos tests should really be time-invariant.