### PR TITLE
IP address support: Address code review comments

### DIFF
--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -13,7 +13,7 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::{
-    cert, name, signed_data, verify_cert, DnsNameOrIpRef, DnsNameRef, Error, SignatureAlgorithm,
+    cert, name, signed_data, verify_cert, DnsNameRef, Error, SignatureAlgorithm, SubjectNameRef,
     TLSClientTrustAnchors, TLSServerTrustAnchors, Time,
 };
 use core::convert::TryFrom;
@@ -27,7 +27,7 @@ use core::convert::TryFrom;
 ///   certificate is currently valid *for use by a TLS server*.
 /// * `EndEntityCert.verify_is_valid_for_dns_name`: Verify that the server's
 ///   certificate is valid for the host that is being connected to.
-/// * `EndEntityCert.verify_is_valid_for_dns_name_or_ip`: Verify that the server's
+/// * `EndEntityCert.verify_is_valid_for_subject_name`: Verify that the server's
 ///   certificate is valid for the host or IP address that is being connected to.
 ///
 /// * `EndEntityCert.verify_signature`: Verify that the signature of server's
@@ -151,12 +151,12 @@ impl<'a> EndEntityCert<'a> {
         name::verify_cert_dns_name(self, dns_name)
     }
 
-    /// Verifies that the certificate is valid for the given DNS host name or IP address.
-    pub fn verify_is_valid_for_dns_name_or_ip(
+    /// Verifies that the certificate is valid for the given Subject Name.
+    pub fn verify_is_valid_for_subject_name(
         &self,
-        dns_name_or_ip: DnsNameOrIpRef,
+        subject_name: SubjectNameRef,
     ) -> Result<(), Error> {
-        name::verify_cert_dns_name_or_ip(self, dns_name_or_ip)
+        name::verify_cert_subject_name(self, subject_name)
     }
 
     /// Verifies the signature `signature` of message `msg` using the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,8 @@ pub use {
     end_entity::EndEntityCert,
     error::Error,
     name::{
-        ip_address::AddrParseError, ip_address::IpAddrRef, DnsNameOrIpRef, DnsNameRef,
-        InvalidDnsNameError, InvalidDnsNameOrIpError,
+        ip_address::AddrParseError, ip_address::IpAddrRef, DnsNameRef, InvalidDnsNameError,
+        InvalidSubjectNameError, SubjectNameRef,
     },
     signed_data::{
         SignatureAlgorithm, ECDSA_P256_SHA256, ECDSA_P256_SHA384, ECDSA_P384_SHA256,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub use {
     end_entity::EndEntityCert,
     error::Error,
     name::{
-        ip_address::InvalidIpAddressError, ip_address::IpAddressRef, DnsNameOrIpRef, DnsNameRef,
+        ip_address::AddrParseError, ip_address::IpAddrRef, DnsNameOrIpRef, DnsNameRef,
         InvalidDnsNameError, InvalidDnsNameOrIpError,
     },
     signed_data::{
@@ -63,7 +63,7 @@ pub use {
 
 #[cfg(feature = "alloc")]
 pub use {
-    name::{ip_address::IpAddress, DnsName},
+    name::{ip_address::IpAddr, DnsName},
     signed_data::{
         RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_2048_8192_SHA384, RSA_PKCS1_2048_8192_SHA512,
         RSA_PKCS1_3072_8192_SHA384, RSA_PSS_2048_8192_SHA256_LEGACY_KEY,

--- a/src/name.rs
+++ b/src/name.rs
@@ -21,9 +21,9 @@ pub use dns_name::DnsName;
 
 #[allow(clippy::module_inception)]
 mod name;
-pub use name::{DnsNameOrIpRef, InvalidDnsNameOrIpError};
+pub use name::{InvalidSubjectNameError, SubjectNameRef};
 
 pub mod ip_address;
 
 mod verify;
-pub(super) use verify::{check_name_constraints, verify_cert_dns_name, verify_cert_dns_name_or_ip};
+pub(super) use verify::{check_name_constraints, verify_cert_dns_name, verify_cert_subject_name};

--- a/src/name.rs
+++ b/src/name.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 Brian Smith.
+// Copyright 2022 Rafael Fernández López.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/src/name/ip_address.rs
+++ b/src/name/ip_address.rs
@@ -12,6 +12,8 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use core::fmt::Write;
+
 use crate::Error;
 
 #[cfg(feature = "alloc")]
@@ -131,17 +133,21 @@ impl<'a> IpAddrRef<'a> {
 
 #[cfg(feature = "std")]
 fn ipv6_to_uncompressed_string(octets: [u8; 16]) -> String {
-    format!(
-        "{:02x?}{:02x?}:{:02x?}{:02x?}:{:02x?}{:02x?}:{:02x?}{:02x?}:{:02x?}{:02x?}:{:02x?}{:02x?}:{:02x?}{:02x?}:{:02x?}{:02x?}",
-        octets[0], octets[1],
-        octets[2], octets[3],
-        octets[4], octets[5],
-        octets[6], octets[7],
-        octets[8], octets[9],
-        octets[10], octets[11],
-        octets[12], octets[13],
-        octets[14], octets[15],
-    )
+    let mut result = String::with_capacity(39);
+    for i in 0..7 {
+        result
+            .write_fmt(format_args!(
+                "{:02x?}{:02x?}:",
+                octets[i * 2],
+                octets[(i * 2) + 1]
+            ))
+            .expect("unexpected error while formatting IPv6 address");
+    }
+    result
+        .write_fmt(format_args!("{:02x?}{:02x?}", octets[14], octets[15]))
+        .expect("unexpected error while formatting IPv6 address");
+
+    result
 }
 
 #[cfg(feature = "std")]

--- a/src/name/verify.rs
+++ b/src/name/verify.rs
@@ -15,7 +15,7 @@
 use super::{
     dns_name::{self, DnsNameRef},
     ip_address::{self, IpAddrRef},
-    name::DnsNameOrIpRef,
+    name::SubjectNameRef,
 };
 use crate::{
     cert::{Cert, EndEntityOrCa},
@@ -45,16 +45,16 @@ pub fn verify_cert_dns_name(
     )
 }
 
-pub fn verify_cert_dns_name_or_ip(
+pub fn verify_cert_subject_name(
     cert: &crate::EndEntityCert,
-    dns_name_or_ip: DnsNameOrIpRef,
+    subject_name: SubjectNameRef,
 ) -> Result<(), Error> {
-    let ip_address = match dns_name_or_ip {
-        DnsNameOrIpRef::DnsName(dns_name) => return verify_cert_dns_name(cert, dns_name),
-        DnsNameOrIpRef::IpAddress(IpAddrRef::V4(_, ref ip_address_octets)) => {
+    let ip_address = match subject_name {
+        SubjectNameRef::DnsName(dns_name) => return verify_cert_dns_name(cert, dns_name),
+        SubjectNameRef::IpAddress(IpAddrRef::V4(_, ref ip_address_octets)) => {
             untrusted::Input::from(ip_address_octets)
         }
-        DnsNameOrIpRef::IpAddress(IpAddrRef::V6(_, ref ip_address_octets)) => {
+        SubjectNameRef::IpAddress(IpAddrRef::V6(_, ref ip_address_octets)) => {
             untrusted::Input::from(ip_address_octets)
         }
     };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -76,19 +76,19 @@ pub fn cloudflare_dns() {
     let check_name = |name: &str| {
         let dns_name_ref = webpki::DnsNameRef::try_from_ascii_str(name).unwrap();
         assert_eq!(Ok(()), cert.verify_is_valid_for_dns_name(dns_name_ref));
-        let dns_name_or_ip_ref = webpki::DnsNameOrIpRef::from(dns_name_ref);
+        let subject_name_ref = webpki::SubjectNameRef::from(dns_name_ref);
         assert_eq!(
             Ok(()),
-            cert.verify_is_valid_for_dns_name_or_ip(dns_name_or_ip_ref)
+            cert.verify_is_valid_for_subject_name(subject_name_ref)
         );
         println!("{:?} ok as name", name);
     };
 
     let check_addr = |addr: &str| {
-        let dns_name_or_ip_ref = webpki::DnsNameOrIpRef::try_from_ascii(addr.as_bytes()).unwrap();
+        let subject_name_ref = webpki::SubjectNameRef::try_from_ascii(addr.as_bytes()).unwrap();
         assert_eq!(
             Ok(()),
-            cert.verify_is_valid_for_dns_name_or_ip(dns_name_or_ip_ref)
+            cert.verify_is_valid_for_subject_name(subject_name_ref)
         );
         println!("{:?} ok as address", addr);
     };


### PR DESCRIPTION
- Mimic std names `IpAddr::V4`, `IpAddr::V6` for owned addresses, as well as `IpAddrRef::V4`, `IpAddrRef::V6` for referenced ones. Also mimic the exception name, now named `AddrParseError` instead of `InvalidIpAddressError`.

- Update copyright header on `name.rs`.

- Reduce the number of allocations on `ipv6_to_uncompressed_string` used to print IPv6 addresses in their uncompressed form.

Other minor changes.

This addresses most of the feedback provided in https://github.com/rustls/webpki/pull/5#pullrequestreview-1231025654.