### PR TITLE
Remove "very first prototype" language

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ and it maintains a tight bound on the amount of stack memory it uses. webpki
 avoids all superfluous PKIX features in order to keep its object code size
 small. Further reducing the code size of webpki is an important goal.
 
-This release is the very first prototype. Lots of improvements are planned,
-including:
+Lots of improvements are planned, including:
 
 * An extensive automated test suite.
 * Key pinning.


### PR DESCRIPTION
I think this code has had enough use and testing to no longer call it a prototype.