### PR TITLE
stronger deprecations.

### DIFF
--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -55,9 +55,12 @@ impl AsRef<str> for DnsName {
 }
 
 /// Requires the `alloc` feature.
-// Deprecated
+/// Deprecated.
 #[cfg(feature = "alloc")]
 impl From<DnsNameRef<'_>> for DnsName {
+    // TODO(XXX): Remove this trait impl in the next release. We can't mark it as
+    //            hard deprecated as this isn't supported and produces a
+    //            'useless_deprecated' warning.
     fn from(dns_name: DnsNameRef) -> Self {
         dns_name.to_owned()
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -25,7 +25,7 @@ pub struct Time(u64);
 impl Time {
     /// Deprecated. Use `TryFrom::try_from`.
     #[cfg(feature = "std")]
-    // Soft deprecation. #[deprecated(note = "Use TryFrom::try_from")]
+    #[deprecated(note = "Use TryFrom::try_from")]
     pub fn try_from(time: std::time::SystemTime) -> Result<Self, ring::error::Unspecified> {
         core::convert::TryFrom::try_from(time)
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -204,5 +204,11 @@ fn read_ee_with_large_pos_serial() {
 #[cfg(feature = "std")]
 #[test]
 fn time_constructor() {
+    // TODO(XXX): Remove when deprecated Time::try_from fn is removed.
+    #[allow(deprecated)]
     let _ = webpki::Time::try_from(std::time::SystemTime::now()).unwrap();
+
+    let _ =
+        <webpki::Time as TryFrom<std::time::SystemTime>>::try_from(std::time::SystemTime::now())
+            .unwrap();
 }

--- a/tests/name_tests.rs
+++ b/tests/name_tests.rs
@@ -41,6 +41,7 @@ fn test_dns_name_traits() {
     let a_ref = DnsNameRef::try_from_ascii(b"example.com").unwrap();
 
     // `From<DnsNameRef>`
+    // TODO(XXX): Remove when deprecated From<DnsNameRef> for DnsName trait is removed.
     let a: DnsName = DnsName::from(a_ref);
 
     // `Clone`, `Debug`, `PartialEq`.
@@ -52,16 +53,22 @@ fn test_dns_name_traits() {
     // PartialEq is case-insensitive
     assert_eq!(
         a,
-        DnsName::from(DnsNameRef::try_from_ascii(b"Example.Com").unwrap())
+        DnsNameRef::try_from_ascii(b"Example.Com")
+            .unwrap()
+            .to_owned()
     );
 
     // PartialEq isn't completely wrong.
     assert_ne!(
         a,
-        DnsName::from(DnsNameRef::try_from_ascii(b"fxample.com").unwrap())
+        DnsNameRef::try_from_ascii(b"fxample.com")
+            .unwrap()
+            .to_owned()
     );
     assert_ne!(
         a,
-        DnsName::from(DnsNameRef::try_from_ascii(b"example.co").unwrap())
+        DnsNameRef::try_from_ascii(b"example.co")
+            .unwrap()
+            .to_owned()
     );
 }


### PR DESCRIPTION
## time: hard deprecate Time::try_from.

Adds a `#[deprecated]` annotation. Updates tests to allow deprecated usage of existing approach and to add usage of the preferred trait.

## subject_name: deprecate From<DnsNameRef> for DnsName.

As mentioned in the commit comment we can't outright `#[deprecate]` this one [because it's a trait impl](https://github.com/rust-lang/rust/issues/39935).

Instead, promote the deprecation note to the rustdoc comment, add a TODO to remove it outright, and switch our own tests to call `to_owned()` directly in preparation of an eventual removal. 

Resolves https://github.com/rustls/webpki/issues/47