### PR TITLE
Preparation for ring 0.17 and untrusted 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ std = ["alloc"]
 
 [dependencies]
 ring = { version = "0.16.19", default-features = false }
-untrusted = "0.7.1"
+untrusted = "0.9.0"
 
 [dev-dependencies]
 base64 = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ alloc = ["ring/alloc"]
 std = ["alloc"]
 
 [dependencies]
-ring = { version = "0.16.19", default-features = false }
+ring = { git = "https://github.com/briansmith/ring", default-features = false }
 untrusted = "0.9.0"
 
 [dev-dependencies]

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -56,7 +56,7 @@ pub(crate) fn parse_cert<'a>(
         // TODO: In mozilla::pkix, the comparison is done based on the
         // normalized value (ignoring whether or not there is an optional NULL
         // parameter for RSA-based algorithms), so this may be too strict.
-        if signature != signed_data.algorithm {
+        if signature.as_slice_less_safe() != signed_data.algorithm.as_slice_less_safe() {
             return Err(Error::SignatureAlgorithmMismatch);
         }
 

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -56,8 +56,12 @@ pub(crate) fn parse_cert<'a>(
         // TODO: In mozilla::pkix, the comparison is done based on the
         // normalized value (ignoring whether or not there is an optional NULL
         // parameter for RSA-based algorithms), so this may be too strict.
-        if signature.as_slice_less_safe() != signed_data.algorithm.as_slice_less_safe() {
-            return Err(Error::SignatureAlgorithmMismatch);
+        match ring::constant_time::verify_slices_are_equal(
+            signature.as_slice_less_safe(),
+            signed_data.algorithm.as_slice_less_safe())
+        {
+            Ok(_) => (),
+            Err(_) => return Err(Error::SignatureAlgorithmMismatch),
         }
 
         let issuer = der::expect_tag_and_get_value(tbs, der::Tag::Sequence)?;

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -312,7 +312,7 @@ struct AlgorithmIdentifier {
 
 impl AlgorithmIdentifier {
     fn matches_algorithm_id_value(&self, encoded: untrusted::Input) -> bool {
-        encoded == self.asn1_id_value
+        encoded.as_slice_less_safe() == self.asn1_id_value.as_slice_less_safe()
     }
 }
 
@@ -459,12 +459,11 @@ mod tests {
     fn test_verify_signed_data_signature_outer(file_contents: &[u8], expected_error: Error) {
         let tsd = parse_test_signed_data(file_contents);
         let signature = untrusted::Input::from(&tsd.signature);
-        assert_eq!(
-            Err(expected_error),
-            signature.read_all(Error::BadDer, |input| {
-                der::bit_string_with_no_unused_bits(input)
-            })
-        );
+        let result = signature.read_all(Error::BadDer, |input| {
+            der::bit_string_with_no_unused_bits(input)
+        });
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), expected_error)
     }
 
     // XXX: This is testing code that is not even in this module.
@@ -480,12 +479,11 @@ mod tests {
     fn test_parse_spki_bad_outer(file_contents: &[u8], expected_error: Error) {
         let tsd = parse_test_signed_data(file_contents);
         let spki = untrusted::Input::from(&tsd.spki);
-        assert_eq!(
-            Err(expected_error),
-            spki.read_all(Error::BadDer, |input| {
-                der::expect_tag_and_get_value(input, der::Tag::Sequence)
-            })
-        );
+        let result = spki.read_all(Error::BadDer, |input| {
+            der::expect_tag_and_get_value(input, der::Tag::Sequence)
+        });
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), expected_error)
     }
 
     const UNSUPPORTED_SIGNATURE_ALGORITHM_FOR_RSA_KEY: Error = if cfg!(feature = "alloc") {

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -312,7 +312,10 @@ struct AlgorithmIdentifier {
 
 impl AlgorithmIdentifier {
     fn matches_algorithm_id_value(&self, encoded: untrusted::Input) -> bool {
-        encoded.as_slice_less_safe() == self.asn1_id_value.as_slice_less_safe()
+        return ring::constant_time::verify_slices_are_equal(
+            encoded.as_slice_less_safe(),
+            self.asn1_id_value.as_slice_less_safe()
+        ).is_ok()
     }
 }
 

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -407,7 +407,7 @@ fn common_name(input: untrusted::Input) -> Result<Option<untrusted::Input>, Erro
         der::nested(tagged, der::Tag::Sequence, Error::BadDer, |tagged| {
             while !tagged.at_end() {
                 let name_oid = der::expect_tag_and_get_value(tagged, der::Tag::OID)?;
-                if name_oid == COMMON_NAME {
+                if name_oid.as_slice_less_safe() == COMMON_NAME.as_slice_less_safe() {
                     return der::expect_tag_and_get_value(tagged, der::Tag::UTF8String).map(Some);
                 } else {
                     // discard unused name value

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -54,18 +54,20 @@ pub(crate) fn build_chain(
     // for the purpose of name constraints checking, only end-entity server certificates
     // could plausibly have a DNS name as a subject commonName that could contribute to
     // path validity
-    let subject_common_name_contents =
-        if required_eku_if_present == EKU_SERVER_AUTH && used_as_ca == UsedAsCa::No {
-            subject_name::SubjectCommonNameContents::DnsName
-        } else {
-            subject_name::SubjectCommonNameContents::Ignore
-        };
+    let subject_common_name_contents = if required_eku_if_present.oid_value.as_slice_less_safe()
+        == EKU_SERVER_AUTH.oid_value.as_slice_less_safe()
+        && used_as_ca == UsedAsCa::No
+    {
+        subject_name::SubjectCommonNameContents::DnsName
+    } else {
+        subject_name::SubjectCommonNameContents::Ignore
+    };
 
     // TODO: revocation.
 
     let result = loop_while_non_fatal_error(trust_anchors, |trust_anchor: &TrustAnchor| {
         let trust_anchor_subject = untrusted::Input::from(trust_anchor.subject);
-        if cert.issuer != trust_anchor_subject {
+        if cert.issuer.as_slice_less_safe() != trust_anchor_subject.as_slice_less_safe() {
             return Err(Error::UnknownIssuer);
         }
 
@@ -93,15 +95,17 @@ pub(crate) fn build_chain(
         let potential_issuer =
             cert::parse_cert(untrusted::Input::from(cert_der), EndEntityOrCa::Ca(cert))?;
 
-        if potential_issuer.subject != cert.issuer {
+        if potential_issuer.subject.as_slice_less_safe() != cert.issuer.as_slice_less_safe() {
             return Err(Error::UnknownIssuer);
         }
 
         // Prevent loops; see RFC 4158 section 5.2.
         let mut prev = cert;
         loop {
-            if potential_issuer.spki.value() == prev.spki.value()
-                && potential_issuer.subject == prev.subject
+            if potential_issuer.spki.value().as_slice_less_safe()
+                == prev.spki.value().as_slice_less_safe()
+                && potential_issuer.subject.as_slice_less_safe()
+                    == prev.subject.as_slice_less_safe()
             {
                 return Err(Error::UnknownIssuer);
             }
@@ -260,7 +264,7 @@ fn check_basic_constraints(
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 pub(crate) struct KeyPurposeId {
     oid_value: untrusted::Input<'static>,
 }
@@ -310,7 +314,9 @@ fn check_eku(
         Some(input) => {
             loop {
                 let value = der::expect_tag_and_get_value(input, der::Tag::OID)?;
-                if value == required_eku_if_present.oid_value {
+                if value.as_slice_less_safe()
+                    == required_eku_if_present.oid_value.as_slice_less_safe()
+                {
                     input.skip_to_end();
                     break;
                 }
@@ -330,7 +336,9 @@ fn check_eku(
             // important that id-kp-OCSPSigning is explicit so that a normal
             // end-entity certificate isn't able to sign trusted OCSP responses
             // for itself or for other certificates issued by its issuing CA.
-            if required_eku_if_present.oid_value == EKU_OCSP_SIGNING.oid_value {
+            if required_eku_if_present.oid_value.as_slice_less_safe()
+                == EKU_OCSP_SIGNING.oid_value.as_slice_less_safe()
+            {
                 return Err(Error::RequiredEkuNotFound);
             }
 


### PR DESCRIPTION
A starting point for https://github.com/rustls/webpki/issues/43.

https://github.com/briansmith/untrusted/commit/36f6dff818bd189e8ab9f57244da40a029d04673 removed equality checks do to security issues by potentially leaking timing information.

This requires checking in which cases the "unsafe" equality can stay and in which cases a constant check can/should be used.

(Two equality checks in test cases are still missing)

Options for  constant time equality checks are maybe:
https://docs.rs/constant_time_eq/latest/constant_time_eq/index.html
https://docs.rs/subtle/2.4.1/subtle/index.html
https://codeberg.org/valpackett/secstr/src/branch/trunk/src/lib.rs#L559

All implementations seem to work with different concepts.  As suggested by @djc , https://github.com/cesarb/constant_time_eq seems to be the most lighweight crate.

