### PR TITLE
Expose GeneralDnsNameRef

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,5 +68,5 @@ pub use {
         RSA_PKCS1_3072_8192_SHA384, RSA_PSS_2048_8192_SHA256_LEGACY_KEY,
         RSA_PSS_2048_8192_SHA384_LEGACY_KEY, RSA_PSS_2048_8192_SHA512_LEGACY_KEY,
     },
-    subject_name::{DnsName, IpAddr},
+    subject_name::{DnsName, GeneralDnsNameRef, IpAddr},
 };

--- a/src/subject_name/mod.rs
+++ b/src/subject_name/mod.rs
@@ -14,7 +14,7 @@
 
 mod dns_name;
 #[cfg(feature = "alloc")]
-pub(crate) use dns_name::GeneralDnsNameRef;
+pub use dns_name::GeneralDnsNameRef;
 pub use dns_name::{DnsNameRef, InvalidDnsNameError};
 
 /// Requires the `alloc` feature.


### PR DESCRIPTION
This is a continuation of the [conversation started here](https://github.com/rustls/webpki/pull/42#discussion_r1169483935), basically I'm going to have thousands of certificates, and I need to look up the right one when a new connection comes in (by reading SNI from the connection).

Looping through thousands of certs and calling [EndEntityCert.html.verify_is_valid_for_dns_name](https://docs.rs/webpki/latest/webpki/struct.EndEntityCert.html#method.verify_is_valid_for_dns_name) on each would be way too slow, I need to look them up via a hashmap, but that means I need to know the difference between a FQDN and a wildcard cert.