### PR TITLE
cert verification rustdoc comment touchups.

### DIFF
--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -106,9 +106,6 @@ impl<'a> EndEntityCert<'a> {
     /// Verifies that the end-entity certificate is valid for use by a TLS
     /// client.
     ///
-    /// If the certificate is not valid for any of the given names then this
-    /// fails with `Error::CertNotValidForName`.
-    ///
     /// `supported_sig_algs` is the list of signature algorithms that are
     /// trusted for use in certificate signatures; the end-entity certificate's
     /// public key is not validated against this list. `trust_anchors` is the

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -287,21 +287,6 @@ pub(crate) static EKU_OCSP_SIGNING: KeyPurposeId = KeyPurposeId {
 };
 
 // https://tools.ietf.org/html/rfc5280#section-4.2.1.12
-//
-// Notable Differences from RFC 5280:
-//
-// * We follow the convention established by Microsoft's implementation and
-//   mozilla::pkix of treating the EKU extension in a CA certificate as a
-//   restriction on the allowable EKUs for certificates issued by that CA. RFC
-//   5280 doesn't prescribe any meaning to the EKU extension when a certificate
-//   is being used as a CA certificate.
-//
-// * We do not recognize anyExtendedKeyUsage. NSS and mozilla::pkix do not
-//   recognize it either.
-//
-// * We treat id-Netscape-stepUp as being equivalent to id-kp-serverAuth in CA
-//   certificates (only). Comodo has issued certificates that require this
-//   behavior that don't expire until June 2020. See https://bugzilla.mozilla.org/show_bug.cgi?id=982292.
 fn check_eku(
     input: Option<&mut untrusted::Reader>,
     required_eku_if_present: KeyPurposeId,


### PR DESCRIPTION
Just a couple small fixes I noticed while studying the path building code and adjacent helpers.

## end_entity: fix tls client cert verify doc comment.
Previously the rustdoc comment on `EndEntityCert.verify_is_valid_tls_client_cert` mentioned that it would
return `Error::CertNotValidForName` if the cert isn't valid for any of the given names. In reality no names are passed into this fn and it will not ever return `CertNotvalidForName`. The caller must use `EndEntityCert.verify_is_valid_for_subject_name` for this purpose.

This commit removes the erroneous mention of name validation from `verify_is_valid_tls_client_cert`.

## verify_cert: remove stale comments on check_eku.
Previously the `check_eku` helper described details of RFC 5280 deviations that no longer match the implementation. In particular, the `id-Netscape-stepUp` EKU workaround was removed (see https://github.com/briansmith/webpki/commit/76da76ef5bf2b00838d8a4cef847b0d28c900f49), and along with it the `used_as_ca` parameter.

Since all that remains of this function is the attempt to match a specific provided EKU (and some special case handing for `id-kp-OCSPSigning`) the comments related to 5280 deviations are removed.

