### PR TITLE
Update MSRV to 1.57 to match rustls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
           toolchain: ${{ matrix.rust_channel }}
 
       - run: |
-          cargo test -vv ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
+          cargo test -vv ${{ matrix.features }} ${{ matrix.mode }}
 
   coverage:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,7 @@ jobs:
         rust_channel:
           - stable
           - nightly
-
-          # MSRV: Rust 1.47 and later have bugs in rustc that prevent some
-          # projects from upgrading past 1.46 yet. So, maintain compatibility
-          # for 1.46 until those bugs are fixed.
-          # Make sure to update rust-version in Cargo.toml when updating MSRV.
-          - 1.46.0
-
+          - 1.57.0
           - beta
 
         exclude:
@@ -121,7 +115,7 @@ jobs:
             rust_channel: nightly
           - features: --all-features
             mode: # debug
-            rust_channel: 1.46.0
+            rust_channel: 1.57.0
           - features: --all-features
             mode: # debug
             rust_channel: beta
@@ -154,7 +148,7 @@ jobs:
 
           - features: --all-features
             mode: # debug
-            rust_channel: 1.46.0
+            rust_channel: 1.57.0
             host_os: ubuntu-20.04
 
           - features: --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 categories = ["cryptography", "no-std"]
 description = "Web PKI X.509 Certificate Verification."
 edition = "2018"
-rust-version = "1.46"
+rust-version = "1.57"
 license-file = "LICENSE"
 name = "rustls-webpki"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 categories = ["cryptography", "no-std"]
 description = "Web PKI X.509 Certificate Verification."
-edition = "2018"
+edition = "2021"
 rust-version = "1.57"
 license-file = "LICENSE"
 name = "rustls-webpki"

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -18,7 +18,6 @@ use crate::{
     cert, signed_data, subject_name, verify_cert, Error, SignatureAlgorithm, SubjectNameRef, Time,
     TlsClientTrustAnchors, TlsServerTrustAnchors,
 };
-use core::convert::TryFrom;
 
 /// An end-entity certificate.
 ///

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -672,6 +672,7 @@ fn is_valid_dns_id(
 mod tests {
     use super::*;
 
+    #[allow(clippy::type_complexity)]
     const PRESENTED_MATCHES_REFERENCE: &[(&[u8], &[u8], Result<bool, Error>)] = &[
         (b"", b"a", Err(Error::MalformedDnsIdentifier)),
         (b"a", b"a", Ok(true)),
@@ -1048,6 +1049,7 @@ mod tests {
     }
 
     // (presented_name, constraint, expected_matches)
+    #[allow(clippy::type_complexity)]
     const PRESENTED_MATCHES_CONSTRAINT: &[(&[u8], &[u8], Result<bool, Error>)] = &[
         // No absolute presented IDs allowed
         (b".", b"", Err(Error::MalformedDnsIdentifier)),

--- a/src/time.rs
+++ b/src/time.rs
@@ -58,7 +58,7 @@ impl core::convert::TryFrom<std::time::SystemTime> for Time {
     /// # extern crate webpki;
     /// #
     /// #![cfg(feature = "std")]
-    /// use std::{convert::TryFrom, time::SystemTime};
+    /// use std::time::SystemTime;
     ///
     /// # fn foo() -> Result<(), ring::error::Unspecified> {
     /// let time = webpki::Time::try_from(SystemTime::now())?;

--- a/tests/cert_v1_unsupported.rs
+++ b/tests/cert_v1_unsupported.rs
@@ -12,8 +12,6 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use core::convert::TryFrom;
-
 #[test]
 fn test_cert_v1_unsupported() {
     // Check with `openssl x509 -text -noout -in cert_v1.der -inform DER`

--- a/tests/cert_without_extensions.rs
+++ b/tests/cert_without_extensions.rs
@@ -12,8 +12,6 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use core::convert::TryFrom;
-
 #[test]
 fn cert_without_extensions_test() {
     // Check the certificate is valid with

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,7 +12,6 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use core::convert::TryFrom;
 extern crate webpki;
 
 static ALL_SIGALGS: &[&webpki::SignatureAlgorithm] = &[

--- a/tests/name_constraints.rs
+++ b/tests/name_constraints.rs
@@ -13,7 +13,6 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #![cfg(feature = "alloc")]
 
-use core::convert::TryFrom;
 extern crate webpki;
 
 static ALL_SIGALGS: &[&webpki::SignatureAlgorithm] = &[


### PR DESCRIPTION
The MSRV was extremely conservative before, much more so than what we have for rustls 1.57.0. I don't think there's much motivation for keeping that, since as far as I know our main (only?) interest is maintaining rustls-webpki for use in rustls (it's right there in the name). Pull it up to 1.57 (which is still pretty conservative!) now that there is something of [a reason](https://github.com/rustls/webpki/pull/44#discussion_r1191011437) to move forward.