### PR TITLE
tests: further cleanup/generalization.

### DIFF
--- a/.github/workflows/testgen.yml
+++ b/.github/workflows/testgen.yml
@@ -48,5 +48,3 @@ jobs:
       - name: Generate test files
         working-directory: ./tests
         run: python3 generate.py
-      - name: Verify Rusts tests pass
-        run: cargo test

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -7,6 +7,7 @@ name-related parts of webpki.
 Run this script from tests/.  It edits the bottom part of tests/name_constraints.rs
 and drops files into tests/name_constraints.
 """
+import argparse
 import os
 from typing import TextIO, Optional, Union, Any, Callable, Iterable, List
 
@@ -824,8 +825,47 @@ def client_auth() -> None:
 
 
 if __name__ == "__main__":
-    name_constraints()
-    signatures()
-    client_auth()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--name-constraints",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Generate name constraint testcases",
+    )
+    parser.add_argument(
+        "--signatures",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Generate signature testcases",
+    )
+    parser.add_argument(
+        "--clientauth",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Generate client auth testcases",
+    )
+    parser.add_argument(
+        "--format",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run cargo fmt post-generation",
+    )
+    parser.add_argument(
+        "--test",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run cargo test post-generation",
+    )
+    args = parser.parse_args()
 
-    subprocess.run("cargo fmt", shell=True, check=True)
+    if args.name_constraints:
+        name_constraints()
+    if args.signatures:
+        signatures()
+    if args.clientauth:
+        client_auth()
+
+    if args.format:
+        subprocess.run("cargo fmt", shell=True, check=True)
+    if args.test:
+        subprocess.run("cargo test", shell=True, check=True)

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -21,10 +21,10 @@ import ipaddress
 import datetime
 import subprocess
 
-ISSUER_PRIVATE_KEY: rsa.RSAPrivateKey = rsa.generate_private_key(
+ROOT_PRIVATE_KEY: rsa.RSAPrivateKey = rsa.generate_private_key(
     public_exponent=65537, key_size=2048, backend=default_backend()
 )
-ISSUER_PUBLIC_KEY: rsa.RSAPublicKey = ISSUER_PRIVATE_KEY.public_key()
+ROOT_PUBLIC_KEY: rsa.RSAPublicKey = ROOT_PRIVATE_KEY.public_key()
 
 NOT_BEFORE: datetime.datetime = datetime.datetime.utcfromtimestamp(0x1FEDF00D - 30)
 NOT_AFTER: datetime.datetime = datetime.datetime.utcfromtimestamp(0x1FEDF00D + 30)
@@ -99,7 +99,7 @@ def end_entity_cert(
         critical=True,
     )
     return ee_builder.sign(
-        private_key=issuer_key if issuer_key is not None else ISSUER_PRIVATE_KEY,
+        private_key=issuer_key if issuer_key is not None else ROOT_PRIVATE_KEY,
         algorithm=hashes.SHA256(),
         backend=default_backend(),
     )
@@ -228,7 +228,7 @@ def generate_name_constraints_test(
     # issuer
     ca: x509.Certificate = ca_cert(
         subject_name=issuer_name,
-        subject_key=ISSUER_PRIVATE_KEY,
+        subject_key=ROOT_PRIVATE_KEY,
         permitted_subtrees=permitted_subtrees,
         excluded_subtrees=excluded_subtrees,
     )
@@ -771,7 +771,7 @@ def generate_client_auth_test(
 
     # issuer
     ca: x509.Certificate = ca_cert(
-        subject_name=issuer_name, subject_key=ISSUER_PRIVATE_KEY
+        subject_name=issuer_name, subject_key=ROOT_PRIVATE_KEY
     )
 
     ca_cert_path: str = os.path.join(output_dir, f"{test_name}.ca.der")

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -4,8 +4,8 @@
 Generates test cases that aim to validate name constraints and other
 name-related parts of webpki.
 
-Run this script from tests/.  It edits the bottom part of tests/name_constraints.rs
-and drops files into tests/name_constraints.
+Run this script from tests/.  It edits the bottom part of some .rs files and
+drops testcase data into subdirectories as required.
 """
 import argparse
 import os


### PR DESCRIPTION
This branch follows https://github.com/rustls/webpki/pull/64 and introduces a few more helpful generalizations/cleanups that I made while writing CRL focused test cases.

Some highlights:

* Lifts out common helper functions for generating end entity and CA certificates that can be shared by several of the more specific test case generators.
* Tidies up some duplicated path manipulation/strings.
* Adds simple command line flags to allow control over which test cases are generated and whether the `cargo fmt` and `cargo test` invocations are run post-generation.
* Generalizes the CA certificate generation to allow generating intermediate certificates in addition to self-signed roots, and to allow optionally specifying key usage.

These changes do not affect the generated test cases so I haven't committed updated test files. We know the generator script + the test cases it spits out still work thanks to the CI improvements that landed in #64 :-) 