### PR TITLE
der/signed_data: introduce support for larger DER values.

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -71,12 +71,10 @@ pub(crate) fn parse_cert<'a>(
     ee_or_ca: EndEntityOrCa<'a>,
 ) -> Result<Cert<'a>, Error> {
     let (tbs, signed_data) = cert_der.read_all(Error::BadDer, |cert_der| {
-        der::nested(
-            cert_der,
-            der::Tag::Sequence,
-            Error::BadDer,
-            signed_data::parse_signed_data,
-        )
+        der::nested(cert_der, der::Tag::Sequence, Error::BadDer, |der| {
+            // limited to SEQUENCEs of size 2^16 or less.
+            signed_data::parse_signed_data(der, der::TWO_BYTE_DER_SIZE)
+        })
     })?;
 
     tbs.read_all(Error::BadDer, |tbs| {

--- a/src/error.rs
+++ b/src/error.rs
@@ -152,3 +152,9 @@ impl fmt::Display for Error {
 /// Requires the `std` feature.
 #[cfg(feature = "std")]
 impl ::std::error::Error for Error {}
+
+impl From<untrusted::EndOfInput> for Error {
+    fn from(_: untrusted::EndOfInput) -> Self {
+        Error::BadDer
+    }
+}

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -65,11 +65,16 @@ pub(crate) struct SignedData<'a> {
 /// The return value's first component is the contents of
 /// `tbsCertificate`/`tbsResponseData`; the second component is a `SignedData`
 /// structure that can be passed to `verify_signed_data`.
+///
+/// The provided size_limit will enforce the largest possible outermost `SEQUENCE` this
+/// function will read.
 pub(crate) fn parse_signed_data<'a>(
     der: &mut untrusted::Reader<'a>,
+    size_limit: usize,
 ) -> Result<(untrusted::Input<'a>, SignedData<'a>), Error> {
-    let (data, tbs) =
-        der.read_partial(|input| der::expect_tag_and_get_value(input, der::Tag::Sequence))?;
+    let (data, tbs) = der.read_partial(|input| {
+        der::expect_tag_and_get_value_limited(input, der::Tag::Sequence, size_limit)
+    })?;
     let algorithm = der::expect_tag_and_get_value(der, der::Tag::Sequence)?;
     let signature = der::bit_string_with_no_unused_bits(der)?;
 


### PR DESCRIPTION
This branch updates the Webpki `der` module to offer some function variants that allow reading a DER encoded tag and value where the value's length can be expressed as a long-form length of up to four bytes. 

To do this we have to lift the `ring::io::der` module's `read_tag_and_get_value` function into `webpki`, since it is hardcoded to support long-form lengths no longer than two bytes and the upstream is not responsive to patches at this time. Once the function is within the `webpki` code and can be modified we tweak it to support lengths up to five bytes, and to allow the caller to specify a maximum `usize` to read. 

The primary use-case for larger values is for supporting using `parse_signed_data` on large CRLs. To enable this the `parse_signed_data` function is updated to accept a `size_limit`. The one existing caller of this function (in cert.rs, for parsing certificates) was previously using the implicit limit imposed by *ring* to read no more than (2^16)-1 bytes. This branch makes that implicit limit into an explicit limit so that there's no risk of DOS from an extremely large certificate. The `CertificateRevocationList::try_from` fn that implements `TryFrom` is updated to allow the maximum supported tagged DER value size (based on the four-byte long-form limit). This will allow loading large CRLs where there is no DOS risk.

Unit test coverage is added both for the new size range and for existing error paths (e.g. high tag number form, non-canonical encodings).

Resolves https://github.com/rustls/webpki/issues/58