### PR TITLE
crl: remove exports of `untrusted::Input`.

### DIFF
--- a/tests/crl_tests.rs
+++ b/tests/crl_tests.rs
@@ -18,8 +18,8 @@ fn parse_valid_crl() {
         0x30, 0x16, 0x80, 0x14, 0x01, 0xDA, 0xBB, 0x7A, 0xCB, 0x25, 0x20, 0x8E, 0x5E, 0x79, 0xD6,
         0xF9, 0x96, 0x42, 0x2F, 0x02, 0x41, 0x29, 0x07, 0xBE,
     ];
-    let aki = crl.authority_key_identifier.expect("missing AKI");
-    assert_eq!(aki.as_slice_less_safe(), expected_aki);
+    let aki = crl.authority_key_identifier().expect("missing AKI");
+    assert_eq!(aki, expected_aki);
 
     // We should find the expected revoked certificate with the expected serial number.
     assert!(crl.find_serial(REVOKED_SERIAL).is_some())


### PR DESCRIPTION
We don't want to add `untrusted` to webpki's public API, but several fields of the `CertificateRevocationList` type did this accidentally when it was added in https://github.com/rustls/webpki/pull/44.

This branch makes the `untrusted::Input` fields crate-private and adds public methods that can return `&[u8]` versions of these fields for external usage.

Along the way I also deleted the `CertificateRevocationLists` type - we didn't export that from `lib.rs`. I added this type before landing on the `CrlProvider` trait implemented in [a separate branch](https://github.com/rustls/webpki/pull/66). With that approach there's no need for a list-of-CRLs type. This also side-steps concerns about the best data structure to use: each `CrlProvider` implementation can choose their own approach.