### PR TITLE
ci: forbid warnings from cargo test.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,8 @@ jobs:
 
       - run: |
           cargo test -vv ${{ matrix.features }} ${{ matrix.mode }}
+        env:
+          RUSTFLAGS: "-D warnings"
 
   coverage:
     runs-on: ubuntu-20.04

--- a/tests/client_auth_revocation.rs
+++ b/tests/client_auth_revocation.rs
@@ -14,6 +14,7 @@
 
 extern crate webpki;
 
+#[cfg(feature = "alloc")]
 static ALL_SIGALGS: &[&webpki::SignatureAlgorithm] = &[
     &webpki::ECDSA_P256_SHA256,
     &webpki::ECDSA_P256_SHA384,
@@ -61,6 +62,7 @@ impl<'a> webpki::CrlProvider<'a> for TestCrls<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 fn check_cert(
     ee: &[u8],
     intermediates: &[&[u8]],


### PR DESCRIPTION
Quick branch to make CI a little bit more strict with respect to warnings in test code.

### tests: fix unused client auth revocation test warns.
The `ALL_SIGALGS` and `check_cert` portions of `client_auth_revocation.rs` are unused when testing without the alloc
feature.

Looking at this more carefully I _think_ the only reason a bunch of this test code is config-gated on `alloc` is that I used RSA keys for the test issuers/keypairs. In a follow-up branch I'll look at making these tests work without alloc. In the meantime, this fixes the warnings.

### ci: forbid warnings from cargo test.
This commit configures the `cargo test` matrix portion of CI to treat any warnings as errors. This will let us catch things like unused imports in test code that shouldn't be merged to main.