### PR TITLE
ci: forbid warnings from cargo test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,8 @@ jobs:
 
       - run: |
           cargo test -vv ${{ matrix.features }} ${{ matrix.mode }}
+        env:
+          RUSTFLAGS: "-D warnings"
 
   coverage:
     runs-on: ubuntu-20.04

--- a/tests/client_auth_revocation.rs
+++ b/tests/client_auth_revocation.rs
@@ -14,6 +14,7 @@
 
 extern crate webpki;
 
+#[cfg(feature = "alloc")]
 static ALL_SIGALGS: &[&webpki::SignatureAlgorithm] = &[
     &webpki::ECDSA_P256_SHA256,
     &webpki::ECDSA_P256_SHA384,
@@ -61,6 +62,7 @@ impl<'a> webpki::CrlProvider<'a> for TestCrls<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 fn check_cert(
     ee: &[u8],
     intermediates: &[&[u8]],

--- a/tests/client_auth_revocation.rs
+++ b/tests/client_auth_revocation.rs
@@ -153,7 +153,7 @@ fn ee_revoked_wrong_ku_ee_depth() {
     let intermediates =
         &[include_bytes!("client_auth_revocation/no_crl_ku_chain.int.ca.der").as_slice()];
     let ca = include_bytes!("client_auth_revocation/no_crl_ku_chain.root.ca.der");
-    let crls = &[webpki::CertRevocationList::try_from(
+    let crls = &[webpki::CertRevocationList::from_der(
         include_bytes!("client_auth_revocation/ee_revoked_wrong_ku_ee_depth.crl.der").as_slice(),
     )
     .unwrap()];
@@ -170,7 +170,7 @@ fn ee_not_revoked_wrong_ku_ee_depth() {
     let intermediates =
         &[include_bytes!("client_auth_revocation/no_crl_ku_chain.int.ca.der").as_slice()];
     let ca = include_bytes!("client_auth_revocation/no_crl_ku_chain.root.ca.der");
-    let crls = &[webpki::CertRevocationList::try_from(
+    let crls = &[webpki::CertRevocationList::from_der(
         include_bytes!("client_auth_revocation/ee_not_revoked_wrong_ku_ee_depth.crl.der")
             .as_slice(),
     )
@@ -204,7 +204,7 @@ fn ee_revoked_crl_ku_ee_depth() {
     let ee = include_bytes!("client_auth_revocation/ku_chain.ee.der");
     let intermediates = &[include_bytes!("client_auth_revocation/ku_chain.int.ca.der").as_slice()];
     let ca = include_bytes!("client_auth_revocation/ku_chain.root.ca.der");
-    let crls = &[webpki::CertRevocationList::try_from(
+    let crls = &[webpki::CertRevocationList::from_der(
         include_bytes!("client_auth_revocation/ee_revoked_crl_ku_ee_depth.crl.der").as_slice(),
     )
     .unwrap()];
@@ -286,7 +286,7 @@ fn int_revoked_wrong_ku_chain_depth() {
     let intermediates =
         &[include_bytes!("client_auth_revocation/no_crl_ku_chain.int.ca.der").as_slice()];
     let ca = include_bytes!("client_auth_revocation/no_crl_ku_chain.root.ca.der");
-    let crls = &[webpki::CertRevocationList::try_from(
+    let crls = &[webpki::CertRevocationList::from_der(
         include_bytes!("client_auth_revocation/int_revoked_wrong_ku_chain_depth.crl.der")
             .as_slice(),
     )
@@ -354,7 +354,7 @@ fn int_revoked_crl_ku_chain_depth() {
     let ee = include_bytes!("client_auth_revocation/ku_chain.ee.der");
     let intermediates = &[include_bytes!("client_auth_revocation/ku_chain.int.ca.der").as_slice()];
     let ca = include_bytes!("client_auth_revocation/ku_chain.root.ca.der");
-    let crls = &[webpki::CertRevocationList::try_from(
+    let crls = &[webpki::CertRevocationList::from_der(
         include_bytes!("client_auth_revocation/int_revoked_crl_ku_chain_depth.crl.der").as_slice(),
     )
     .unwrap()];


### PR DESCRIPTION
Quick branch to make CI a little bit more strict with respect to warnings in test code, and to fix some test failures.

### tests: fixup merge errs.
We had a small merge snafu where the `try_from` trait was removed in one branch, but another branch had landed first that added more tests using it. This commit fixes those tests to use `from_der` instead of the missing `try_from` fn. 

I'll start a discussion about repo settings we can explore to prevent this in the future.

### tests: fix unused client auth revocation test warns.
The `ALL_SIGALGS` and `check_cert` portions of `client_auth_revocation.rs` are unused when testing without the alloc
feature.

Looking at this more carefully I _think_ the only reason a bunch of this test code is config-gated on `alloc` is that I used RSA keys for the test issuers/keypairs. In a follow-up branch I'll look at making these tests work without alloc. In the meantime, this fixes the warnings.

### ci: forbid warnings from cargo test.
This commit configures the `cargo test` matrix portion of CI to treat any warnings as errors. This will let us catch things like unused imports in test code that shouldn't be merged to main.