### PR TITLE
crl: explicitly number RevocationReason codes.

### DIFF
--- a/src/crl.rs
+++ b/src/crl.rs
@@ -388,17 +388,18 @@ impl<'a> RevokedCert<'a> {
 pub enum RevocationReason {
     /// Unspecified should not be used, and is instead assumed by the absence of a RevocationReason
     /// extension.
-    Unspecified,
-    KeyCompromise,
-    CaCompromise,
-    AffiliationChanged,
-    Superseded,
-    CessationOfOperation,
-    CertificateHold,
+    Unspecified = 0,
+    KeyCompromise = 1,
+    CaCompromise = 2,
+    AffiliationChanged = 3,
+    Superseded = 4,
+    CessationOfOperation = 5,
+    CertificateHold = 6,
+    // 7 is not used.
     /// RemoveFromCrl only appears in delta CRLs that are unsupported.
-    RemoveFromCrl,
-    PrivilegeWithdrawn,
-    AaCompromise,
+    RemoveFromCrl = 8,
+    PrivilegeWithdrawn = 9,
+    AaCompromise = 10,
 }
 
 impl RevocationReason {

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -89,8 +89,6 @@ fn build_chain_inner(
             subject_name::SubjectCommonNameContents::Ignore
         };
 
-    // TODO: revocation.
-
     let result = loop_while_non_fatal_error(
         Error::UnknownIssuer,
         opts.trust_anchors,


### PR DESCRIPTION
The `RevocationReaason` enum should use explicit c-style enum values in order to make sure that the values line up with the RFC defined codes. In particular, since 7 is not used we want to make sure that `RemoveFromCrl` is 8.

_(Also removes a stale `todo` about revocation support in `verify_cert.rs)_