### PR TITLE
Small breaking API changes removing deprecated items.

### DIFF
--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -53,18 +53,6 @@ impl AsRef<str> for DnsName {
     }
 }
 
-/// Requires the `alloc` feature.
-/// Deprecated.
-#[cfg(feature = "alloc")]
-impl From<DnsNameRef<'_>> for DnsName {
-    // TODO(XXX): Remove this trait impl in the next release. We can't mark it as
-    //            hard deprecated as this isn't supported and produces a
-    //            'useless_deprecated' warning.
-    fn from(dns_name: DnsNameRef) -> Self {
-        dns_name.to_owned()
-    }
-}
-
 /// A reference to a DNS Name suitable for use in the TLS Server Name Indication
 /// (SNI) extension and/or for use as the reference hostname for which to verify
 /// a certificate.

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -77,10 +77,12 @@ impl From<DnsNameRef<'_>> for DnsName {
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
 pub struct DnsNameRef<'a>(pub(crate) &'a [u8]);
 
-impl AsRef<[u8]> for DnsNameRef<'_> {
+impl AsRef<str> for DnsNameRef<'_> {
     #[inline]
-    fn as_ref(&self) -> &[u8] {
-        self.0
+    fn as_ref(&self) -> &str {
+        // The unwrap won't fail because DnsNameRef are guaranteed to be ASCII
+        // and ASCII is a subset of UTF-8.
+        core::str::from_utf8(self.0).unwrap()
     }
 }
 

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -32,7 +32,7 @@ pub(crate) fn verify_cert_dns_name(
     dns_name: DnsNameRef,
 ) -> Result<(), Error> {
     let cert = cert.inner();
-    let dns_name = untrusted::Input::from(dns_name.as_ref());
+    let dns_name = untrusted::Input::from(dns_name.as_ref().as_bytes());
     iterate_names(
         Some(cert.subject),
         cert.subject_alt_name,

--- a/src/time.rs
+++ b/src/time.rs
@@ -23,13 +23,6 @@
 pub struct Time(u64);
 
 impl Time {
-    /// Deprecated. Use `TryFrom::try_from`.
-    #[cfg(feature = "std")]
-    #[deprecated(note = "Use TryFrom::try_from")]
-    pub fn try_from(time: std::time::SystemTime) -> Result<Self, ring::error::Unspecified> {
-        TryFrom::try_from(time)
-    }
-
     /// Create a `webpki::Time` from a unix timestamp.
     ///
     /// It is usually better to use the less error-prone
@@ -44,8 +37,7 @@ impl Time {
 
 #[cfg(feature = "std")]
 impl TryFrom<std::time::SystemTime> for Time {
-    // TODO: In the next release, make this `std::time::SystemTimeError`.
-    type Error = ring::error::Unspecified;
+    type Error = std::time::SystemTimeError;
 
     /// Create a `webpki::Time` from a `std::time::SystemTime`.
     ///
@@ -60,7 +52,7 @@ impl TryFrom<std::time::SystemTime> for Time {
     /// #![cfg(feature = "std")]
     /// use std::time::SystemTime;
     ///
-    /// # fn foo() -> Result<(), ring::error::Unspecified> {
+    /// # fn foo() -> Result<(), std::time::SystemTimeError> {
     /// let time = webpki::Time::try_from(SystemTime::now())?;
     /// # Ok(())
     /// # }
@@ -69,6 +61,5 @@ impl TryFrom<std::time::SystemTime> for Time {
         value
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| Self::from_seconds_since_unix_epoch(d.as_secs()))
-            .map_err(|_| ring::error::Unspecified)
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -203,10 +203,6 @@ fn read_ee_with_large_pos_serial() {
 #[cfg(feature = "std")]
 #[test]
 fn time_constructor() {
-    // TODO(XXX): Remove when deprecated Time::try_from fn is removed.
-    #[allow(deprecated)]
-    let _ = webpki::Time::try_from(std::time::SystemTime::now()).unwrap();
-
     let _ =
         <webpki::Time as TryFrom<std::time::SystemTime>>::try_from(std::time::SystemTime::now())
             .unwrap();

--- a/tests/name_tests.rs
+++ b/tests/name_tests.rs
@@ -39,10 +39,7 @@ fn test_dns_name_traits() {
     compile_time_assert_sync::<DnsName>();
 
     let a_ref = DnsNameRef::try_from_ascii(b"example.com").unwrap();
-
-    // `From<DnsNameRef>`
-    // TODO(XXX): Remove when deprecated From<DnsNameRef> for DnsName trait is removed.
-    let a: DnsName = DnsName::from(a_ref);
+    let a = a_ref.to_owned();
 
     // `Clone`, `Debug`, `PartialEq`.
     assert_eq!(&a, &a.clone());


### PR DESCRIPTION
In preparation for considering a major release this branch resolves a few items we had flagged as breaking changes.

### subject_name: replace AsRef<[u8]> with AsRef<str>.
This commit replaces the `DnsNameRef` type's `AsRef<[u8]>` implementation with a `AsRef<str>` replacement.

We know the contents of a `DnsNameRef` are valid UTF-8 and it's trivial to go from `&str` to `&[u8]` making the `AsRef<str>` option a more capable API.

Resolves https://github.com/rustls/webpki/issues/45

### subject_name: remove deprecated DnsName From trait.

This trait was marked as deprecated in a comment (it couldn't be hard-deprecated as a trait impl), let's remove it before the next breaking release.

### time: remove deprecated try_from, avoid ring err.
This commit removes the manually implemented `try_from` on `Time` that was marked as deprecated. Users should prefer `TryFrom::try_from`. 

Similarly, we update the `TryFrom` impl for `Time` to return `std::time::SystemTimeError` for error conditions instead of leaking the *ring* dependency by returning `ring::error::Unspecified`.

Resolves https://github.com/rustls/webpki/issues/63

