### PR TITLE
tests: avoid messy testfile churn from generate.py

### DIFF
--- a/.github/workflows/testgen.yml
+++ b/.github/workflows/testgen.yml
@@ -47,4 +47,6 @@ jobs:
         run: pip install -r requirements.txt
       - name: Generate test files
         working-directory: ./tests
-        run: python3 generate.py
+        # Run generate with `--force` to ensure freshly generated certs/keys
+        # pass `cargo test`.
+        run: python3 generate.py --force


### PR DESCRIPTION
### tests: avoid messy testfile churn from generate.py
Typically when we make changes to generated tests we don't need to regenerate the binary certificates, private keys, and signature messages. Doing so is non-deterministic and muddies our diffs with lots of unrelated changes.

This commit improves the situation by defaulting to not overwriting existing keys/certs when running `generate.py` unless `--force` is provided. We will still do a little bit of unnecessary work generating keypairs/certs that won't be serialized but it avoids a more substantial rework of the generation code while still achieving our goal of avoiding
extra noise.

### ci: run generate.py with --force in testgen.
This way we can be sure that the code to generate fresh certs/keys for our generated test cases work as expected.
