### PR TITLE
ci: run generate w/o --force.

### DIFF
--- a/.github/workflows/testgen.yml
+++ b/.github/workflows/testgen.yml
@@ -47,6 +47,4 @@ jobs:
         run: pip install -r requirements.txt
       - name: Generate test files
         working-directory: ./tests
-        # Run generate with `--force` to ensure freshly generated certs/keys
-        # pass `cargo test`.
-        run: python3 generate.py --force
+        run: python3 generate.py


### PR DESCRIPTION
Previously we reworked `generate.py` to only overwrite generated resources when run with `--force`, and then added `--force` to the CI testgen run.

In retrospect it seems better to not overwrite test content without looking, when it could end up testing something out-of-sync with what's in-tree.

This commit removes `--force` from the CI `generate.py` task.