### PR TITLE
ci: enforce generate.py produces no diff.

### DIFF
--- a/.github/workflows/testgen.yml
+++ b/.github/workflows/testgen.yml
@@ -47,6 +47,8 @@ jobs:
         run: pip install -r requirements.txt
       - name: Generate test files
         working-directory: ./tests
-        # Run generate with `--force` to ensure freshly generated certs/keys
-        # pass `cargo test`.
-        run: python3 generate.py --force
+        # Generate but don't run the test suite - we already do that in the
+        # other CI tasks that run `cargo test`.
+        run: python3 generate.py --no-test
+      - name: Enforce no diff
+        run: git diff --exit-code


### PR DESCRIPTION
Previously we ran `generate.py` with `--force` and default arguments in CI. This is suboptimal in that it silently overwrites test files without anyone looking at them and means we're testing something other than what's checked in to git.

This commit takes a different approach and removes the `--force` arg. We also skip running `cargo test` by providing `--no-test` and instead just verify that running generate produces no diff from what's been checked in-tree and tested in the other CI task.