### PR TITLE
der/crl: fix support for large CRL DER.

### DIFF
--- a/src/crl.rs
+++ b/src/crl.rs
@@ -21,7 +21,6 @@ use crate::{der, signed_data, Error, Time};
 /// [^1]: <https://www.rfc-editor.org/rfc/rfc5280#section-5>
 pub struct CertRevocationList<'a> {
     /// A `SignedData` structure that can be passed to `verify_signed_data`.
-    #[allow(unused)] // TODO(@cpu): Remove when support for revocation checking is added.
     pub(crate) signed_data: signed_data::SignedData<'a>,
 
     /// Identifies the entity that has signed and issued this

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -59,9 +59,13 @@ impl<'a> CertRevocationList<'a> {
         // Try to parse the CRL.
         let reader = untrusted::Input::from(crl_der);
         let (tbs_cert_list, signed_data) = reader.read_all(Error::BadDer, |crl_der| {
-            der::nested(crl_der, Tag::Sequence, Error::BadDer, |signed_der| {
-                signed_data::parse_signed_data(signed_der, der::MAX_DER_SIZE)
-            })
+            der::nested_limited(
+                crl_der,
+                Tag::Sequence,
+                Error::BadDer,
+                |signed_der| signed_data::parse_signed_data(signed_der, der::MAX_DER_SIZE),
+                der::MAX_DER_SIZE,
+            )
         })?;
 
         let crl = tbs_cert_list.read_all(Error::BadDer, |tbs_cert_list| {
@@ -109,7 +113,11 @@ impl<'a> CertRevocationList<'a> {
             //   MUST be absent
             // TODO(@cpu): Do we care to support empty CRLs if we don't support delta CRLs?
             let revoked_certs = if tbs_cert_list.peek(Tag::Sequence.into()) {
-                der::expect_tag_and_get_value(tbs_cert_list, Tag::Sequence)?
+                der::expect_tag_and_get_value_limited(
+                    tbs_cert_list,
+                    Tag::Sequence,
+                    der::MAX_DER_SIZE,
+                )?
             } else {
                 untrusted::Input::from(&[])
             };

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -207,7 +207,6 @@ struct CertNotRevoked(());
 
 impl CertNotRevoked {
     // Construct a CertNotRevoked marker.
-    #[allow(unused)] // TODO(@cpu): remove in subsequent commits.
     fn assertion() -> Self {
         Self(())
     }


### PR DESCRIPTION
Lifting the actionable parts out of https://github.com/rustls/webpki/pull/92

### crl: remove unnecessary unused clippy allows.

These were meant to be removed in earlier work and were overlooked.

### der/crl: fix support for large CRL DER.
Previously (https://github.com/rustls/webpki/pull/73) we updated the `der` module to have methods that allow specifying an explicit size limit so that the `crl` module could opt-in to reading DER values larger than the implicit maximum supported by *ring*. 

Unfortunately this update wasn't quite complete: we need a `der::nested_limited` version of `der::nested` to read the nested sequence with the large signed data we pass to `signed_data::parse_signed_data` or we'll run into the implicit limit before we get to the parsing that supports a larger data size.

Similarly when reading the `SEQUENCE` that holds all of the revoked certificates we need to use `der::expect_tag_and_get_value_limited` with a large limit instead of using `der::expect_tag_and_get_value` with the implicit limit. This sequence is expected to be quite large when there are a large number of revoked certs.