### PR TITLE
lib: remove stale html_root_url doc attribute.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //! | `alloc` | Enable features that require use of the heap. Currently all RSA signature algorithms require this feature. |
 //! | `std` | Enable features that require libstd. Implies `alloc`. |
 
-#![doc(html_root_url = "https://briansmith.org/rustdoc/")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(unreachable_pub)]
 #![deny(warnings, missing_docs, clippy::as_conversions)]


### PR DESCRIPTION
The Rustls fork of webpki doesn't host rustdocs somewhere that would require a `html_root_url` doc attribute override. This commit removes the stale instance from the upstream crate this one was forked from.