### PR TITLE
ci: add merge_group trigger to ci tasks.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ permissions:
 on:
   pull_request:
   push:
+  merge_group:
 jobs:
   rustfmt:
     runs-on: ubuntu-20.04

--- a/.github/workflows/testgen.yml
+++ b/.github/workflows/testgen.yml
@@ -4,6 +4,7 @@ permissions:
 on:
   pull_request:
   push:
+  merge_group:
 env:
   PYTHON_VERSION: "3.11"
 jobs:


### PR DESCRIPTION
This commit adds `merge_group` to our CI task `on` triggers in preparation for enabling the merge queue feature.

Per the [GitHub docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)

> You must use the merge_group event to trigger your GitHub Actions
> workflow when a pull request is added to a merge queue.
>
> Note: If your repository uses GitHub Actions to perform required
> checks on pull requests in your repository, you need to update the
> workflows to include the merge_group event as an additional trigger.
> Otherwise, status checks will not be triggered when you add a pull
> request to a merge queue. The merge will fail as the required status
> check will not be reported. The merge_group event is separate from the
> pull_request and push events.
