### PR TITLE
docs: sync SECURITY.md backport policy w/ Rustls.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,15 @@
 
 ## Supported Versions
 
-Security fixes will be backported to the most recent three minor version lines.
+Security fixes will be backported only to the webpki versions for which the
+original semver-compatible release was published less than 2 years ago.
+
+For example, as of 2023-06-13 the latest release is 0.100.1
+
+* 0.100.0 was released in March of 2023
+* 0.17.0 was released in August of 2017
+
+Therefore 0.100.x ill be updated, while 0.17.x will not be.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Over in the main Rustls repo we updated the `SECURITY.md` policy on supported versions to give more detail (https://github.com/rustls/rustls/pull/1315).

This commit synchronizes the webpki `SECURITY.md` to match.