### PR TITLE
benches: CRL parsing/searching benchmarks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ target/
 # IntelliJ junk
 *.iml
 .idea
+
+# Benchmark data
+benches/*.der

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,9 @@ untrusted = "0.7.1"
 
 [dev-dependencies]
 base64 = "0.13"
+bencher = "0.1.5"
+once_cell = "1.17.2"
+rcgen = { version = "0.11.1", default-features = false }
 
 [profile.bench]
 opt-level = 3
@@ -88,3 +91,12 @@ rpath = false
 lto = true
 debug-assertions = false
 codegen-units = 1
+
+[[bench]]
+name = "benchmarks"
+path = "benches/benchmark.rs"
+harness = false
+
+[patch.crates-io]
+# TODO(XXX): Remove this once rcgen has cut a release w/ CRL support included.
+rcgen = { git = 'https://github.com/est31/rcgen.git' }

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,0 +1,231 @@
+use bencher::{benchmark_group, benchmark_main, Bencher};
+use once_cell::sync::Lazy;
+use rcgen::{
+    date_time_ymd, BasicConstraints, Certificate, CertificateParams, CertificateRevocationList,
+    CertificateRevocationListParams, IsCa, KeyIdMethod, KeyUsagePurpose, RevocationReason,
+    RevokedCertParams, SerialNumber, PKCS_ECDSA_P256_SHA256,
+};
+
+use std::fs::File;
+use std::hint::black_box;
+use std::io::{ErrorKind, Read, Write};
+use std::path::Path;
+use std::sync::Mutex;
+
+use webpki::{BorrowedCertRevocationList, CertRevocationList};
+
+/// Lazy initialized CRL issuer to be used when generating CRL data. Includes
+/// `KeyUsagePurpose::CrlSign` key usage bit.
+static CRL_ISSUER: Lazy<Mutex<Certificate>> = Lazy::new(|| {
+    let mut issuer_params = CertificateParams::new(vec!["crl.issuer.example.com".to_string()]);
+    issuer_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    issuer_params.key_usages = vec![
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::CrlSign,
+    ];
+    Mutex::new(Certificate::from_params(issuer_params).unwrap())
+});
+
+/// Number of revoked certificates to include in the small benchmark CRL. Produces a CRL roughly
+/// ~72kb in size when serialized to disk.
+const SMALL_CRL_CERT_COUNT: usize = 2_000;
+/// Number of revoked certificates to include in the medium benchmark CRL. Produces a CRL roughly
+/// ~22mb in size when serialized to disk.
+const MEDIUM_CRL_CERT_COUNT: usize = 600_000;
+/// Number of revoked certificates to include in the large benchmark CRL. Produces a CRL roughly
+/// ~50mb in size when serialized to disk.
+const LARGE_CRL_CERT_COUNT: usize = 1_500_000;
+
+/// A fake serial number to use in the search tests. In order to provoke a full scan of the CRL
+/// contents this serial should **not** appear in the revoked certificates.
+const FAKE_SERIAL: &[u8] = &[0xC0, 0xFF, 0xEE];
+
+/// Try to load a DER bytes from `crl_path`. If that file path does not exist, generate a CRL
+/// with `revoked_count` revoked certificates, write the DER encoding to `crl_path` and return the
+/// newly created DER bytes.
+fn load_or_generate(crl_path: impl AsRef<Path> + Copy, revoked_count: usize) -> Vec<u8> {
+    match File::open(crl_path) {
+        Ok(mut crl_file) => {
+            let mut crl_der = Vec::new();
+            crl_file.read_to_end(&mut crl_der).unwrap();
+            return crl_der;
+        }
+        Err(e) => match e.kind() {
+            ErrorKind::NotFound => match File::create(crl_path) {
+                Err(e) => panic!("unexpected err creating CRL file: {:?}", e),
+                Ok(mut crl_file) => {
+                    let new_crl = generate_crl(revoked_count);
+                    crl_file.write_all(&new_crl).unwrap();
+                    return new_crl;
+                }
+            },
+            e => {
+                panic!("unexpected err opening CRL file: {:?}", e);
+            }
+        },
+    }
+}
+
+/// Create a new benchmark CRL with `revoked_count` revoked certificates.
+fn generate_crl(revoked_count: usize) -> Vec<u8> {
+    let mut revoked_certs = Vec::with_capacity(revoked_count);
+    (0..revoked_count).for_each(|i| {
+        revoked_certs.push(RevokedCertParams {
+            serial_number: SerialNumber::from((i + 1) as u64),
+            revocation_time: date_time_ymd(2024, 06, 17),
+            reason_code: Some(RevocationReason::KeyCompromise),
+            invalidity_date: None,
+        });
+    });
+
+    let crl = CertificateRevocationListParams {
+        this_update: date_time_ymd(2023, 06, 17),
+        next_update: date_time_ymd(2024, 06, 17),
+        crl_number: SerialNumber::from(1234),
+        alg: &PKCS_ECDSA_P256_SHA256,
+        key_identifier_method: KeyIdMethod::Sha256,
+        revoked_certs,
+    };
+    let crl = CertificateRevocationList::from_params(crl).unwrap();
+    let issuer = CRL_ISSUER.lock().unwrap();
+    crl.serialize_der_with_signer(&issuer).unwrap()
+}
+
+/// Benchmark parsing a small CRL file into a borrowed representation.
+fn bench_parse_borrowed_crl_small(c: &mut Bencher) {
+    let crl_bytes = load_or_generate("./benches/small.crl.der", SMALL_CRL_CERT_COUNT);
+
+    c.iter(|| BorrowedCertRevocationList::from_der(&crl_bytes).unwrap());
+}
+
+/// Benchmark parsing a small CRL file into an owned representation.
+fn bench_parse_owned_crl_small(c: &mut Bencher) {
+    let crl_bytes = load_or_generate("./benches/small.crl.der", SMALL_CRL_CERT_COUNT);
+
+    c.iter(|| {
+        BorrowedCertRevocationList::from_der(&crl_bytes)
+            .unwrap()
+            .to_owned()
+            .unwrap()
+    });
+}
+
+/// Benchmark parsing a medium CRL file into a borrowed representation..
+fn bench_parse_borrowed_crl_medium(c: &mut Bencher) {
+    let crl_bytes = load_or_generate("./benches/medium.crl.der", MEDIUM_CRL_CERT_COUNT);
+
+    c.iter(|| BorrowedCertRevocationList::from_der(&crl_bytes).unwrap());
+}
+
+/// Benchmark parsing a medium CRL file into an owned representation..
+fn bench_parse_owned_crl_medium(c: &mut Bencher) {
+    let crl_bytes = load_or_generate("./benches/medium.crl.der", MEDIUM_CRL_CERT_COUNT);
+
+    c.iter(|| {
+        BorrowedCertRevocationList::from_der(&crl_bytes)
+            .unwrap()
+            .to_owned()
+            .unwrap()
+    });
+}
+
+/// Benchmark parsing a large CRL file into a borrowed representation..
+fn bench_parse_borrowed_crl_large(c: &mut Bencher) {
+    let crl_bytes = load_or_generate("./benches/large.crl.der", LARGE_CRL_CERT_COUNT);
+
+    c.iter(|| BorrowedCertRevocationList::from_der(&crl_bytes).unwrap());
+}
+
+/// Benchmark parsing a large CRL file into an owned representation..
+fn bench_parse_owned_crl_large(c: &mut Bencher) {
+    let crl_bytes = load_or_generate("./benches/large.crl.der", LARGE_CRL_CERT_COUNT);
+
+    c.iter(|| {
+        BorrowedCertRevocationList::from_der(&crl_bytes)
+            .unwrap()
+            .to_owned()
+            .unwrap()
+    });
+}
+
+/// Benchmark searching a small CRL file in borrowed representation for a serial that does not
+/// appear. Doesn't include the time it takes to parse the CRL in the benchmark task.
+fn bench_search_borrowed_crl_small(c: &mut Bencher) {
+    let crl_bytes = load_or_generate("./benches/small.crl.der", SMALL_CRL_CERT_COUNT);
+    let crl = BorrowedCertRevocationList::from_der(&crl_bytes).unwrap();
+
+    c.iter(|| black_box(assert!(matches!(crl.find_serial(FAKE_SERIAL), Ok(None)))));
+}
+
+/// Benchmark searching a small CRL file in owned representation for a serial that does not
+/// appear. Doesn't include the time it takes to parse the CRL in the benchmark task.
+fn bench_search_owned_crl_small(c: &mut Bencher) {
+    let crl_bytes = load_or_generate("./benches/small.crl.der", SMALL_CRL_CERT_COUNT);
+    let crl = BorrowedCertRevocationList::from_der(&crl_bytes)
+        .unwrap()
+        .to_owned()
+        .unwrap();
+
+    c.iter(|| black_box(assert!(matches!(crl.find_serial(FAKE_SERIAL), Ok(None)))));
+}
+
+/// Benchmark searching a medium CRL file in borrowed representation for a serial that does not
+/// appear. Doesn't include the time it takes to parse the CRL in the benchmark task.
+fn bench_search_borrowed_crl_medium(c: &mut Bencher) {
+    let crl_bytes = load_or_generate("./benches/medium.crl.der", MEDIUM_CRL_CERT_COUNT);
+    let crl = BorrowedCertRevocationList::from_der(&crl_bytes).unwrap();
+
+    c.iter(|| black_box(assert!(matches!(crl.find_serial(FAKE_SERIAL), Ok(None)))));
+}
+
+/// Benchmark searching a medium CRL file in owned representation for a serial that does not
+/// appear. Doesn't include the time it takes to parse the CRL in the benchmark task.
+fn bench_search_owned_crl_medium(c: &mut Bencher) {
+    let crl_bytes = load_or_generate("./benches/medium.crl.der", MEDIUM_CRL_CERT_COUNT);
+    let crl = BorrowedCertRevocationList::from_der(&crl_bytes)
+        .unwrap()
+        .to_owned()
+        .unwrap();
+
+    c.iter(|| black_box(assert!(matches!(crl.find_serial(FAKE_SERIAL), Ok(None)))));
+}
+
+/// Benchmark searching a large CRL file in borrowed representation for a serial that does not
+/// appear. Doesn't include the time it takes to parse the CRL in the benchmark task.
+fn bench_search_borrowed_crl_large(c: &mut Bencher) {
+    let crl_bytes = load_or_generate("./benches/large.crl.der", LARGE_CRL_CERT_COUNT);
+    let crl = BorrowedCertRevocationList::from_der(&crl_bytes).unwrap();
+
+    c.iter(|| black_box(assert!(matches!(crl.find_serial(FAKE_SERIAL), Ok(None)))));
+}
+
+/// Benchmark searching a large CRL file in owned representation for a serial that does not
+/// appear. Doesn't include the time it takes to parse the CRL in the benchmark task.
+fn bench_search_owned_crl_large(c: &mut Bencher) {
+    let crl_bytes = load_or_generate("./benches/large.crl.der", LARGE_CRL_CERT_COUNT);
+    let crl = BorrowedCertRevocationList::from_der(&crl_bytes)
+        .unwrap()
+        .to_owned()
+        .unwrap();
+
+    c.iter(|| black_box(assert!(matches!(crl.find_serial(FAKE_SERIAL), Ok(None)))));
+}
+
+benchmark_group!(
+    crl_benches,
+    bench_parse_borrowed_crl_small,
+    bench_parse_owned_crl_small,
+    bench_parse_borrowed_crl_medium,
+    bench_parse_owned_crl_medium,
+    bench_parse_borrowed_crl_large,
+    bench_parse_owned_crl_large,
+    bench_search_borrowed_crl_small,
+    bench_search_owned_crl_small,
+    bench_search_borrowed_crl_medium,
+    bench_search_owned_crl_medium,
+    bench_search_borrowed_crl_large,
+    bench_search_owned_crl_large,
+);
+
+benchmark_main!(crl_benches);

--- a/deny.toml
+++ b/deny.toml
@@ -39,3 +39,9 @@ wildcards = "deny"
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+
+# Dev dependency only.
+# TODO(@cpu): Remove once rcgen cuts a release w/ crl support.
+allow-git = [
+  "https://github.com/est31/rcgen"
+]


### PR DESCRIPTION
This branch adds two kinds of CRL benchmark tests:

1. Parsing benchmarks, testing how long it takes to use `BorrowedCertRevocationList::from_der`, as well as how long it takes to do the same converting to the `OwnedCertRevocationList` representation that allocates.
2. Searching benchmarks, testing how long it takes to search an already parsed CRL for a serial number that doesn't appear in the CRL. This is done for both the borrowed and owned representations.

In both cases we add benchmarks that use three sizes of CRLs:

1. a small CRL (2,000 serials, ~72kb)
2. a medium CRL (600,000 serials, ~22mb)
3. a large CRL (1,500,000 serials, ~50mb)

Since large test files aren't suitable for inclusion in git, these CRLs are generated on first benchmark run using `rcgen`. We use a Cargo patch to use the master branch of this dev-dependency for CRL support.

Initial results from my laptop:
```
Running benches/benchmark.rs (target/release/deps/benchmarks-b6e36ee32c803b65)

running 12 tests
test bench_parse_borrowed_crl_large   ... bench:          49 ns/iter (+/- 12)
test bench_parse_borrowed_crl_medium  ... bench:          51 ns/iter (+/- 4)
test bench_parse_borrowed_crl_small   ... bench:          53 ns/iter (+/- 1)
test bench_parse_owned_crl_large      ... bench: 502,094,511 ns/iter (+/- 106,915,574)
test bench_parse_owned_crl_medium     ... bench: 183,980,410 ns/iter (+/- 10,231,635)
test bench_parse_owned_crl_small      ... bench:     188,714 ns/iter (+/- 9,487)
test bench_search_borrowed_crl_large  ... bench:  42,466,919 ns/iter (+/- 4,490,349)
test bench_search_borrowed_crl_medium ... bench:  16,940,885 ns/iter (+/- 823,770)
test bench_search_borrowed_crl_small  ... bench:      53,643 ns/iter (+/- 7,362)
test bench_search_owned_crl_large     ... bench:          10 ns/iter (+/- 4)
test bench_search_owned_crl_medium    ... bench:           9 ns/iter (+/- 2)
test bench_search_owned_crl_small     ... bench:          10 ns/iter (+/- 1)

test result: ok. 0 passed; 0 failed; 0 ignored; 12 measured
```

Laptop specs:
* rustc 1.69.0
* NixOS 22.11
* 12th Gen Intel(R) Core(TM) i7-1280P
* 32GB DDR4-3200
* WD_BLACK SN850 NVMe