### PR TITLE
codecov: use upload token to improve reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,7 @@ jobs:
 
       - uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
           files: ./lcov.info
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
(I have added a github actions secret named `CODECOV_UPLOAD_TOKEN` which is the "Repository upload token" from codecov.io.) For background, see: https://github.com/codecov/codecov-action/issues/837#issuecomment-1453877750