### PR TITLE
fix 32 bit support, add i686-unknown-linux-gnu CI target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,17 @@ jobs:
           toolchain: 1.57.0
       - run: cargo check --lib --all-features
 
+  cross:
+    name: Check cross compilation targets
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo install cross
+      - run: cross build --target i686-unknown-linux-gnu
+
   coverage:
     runs-on: ubuntu-20.04
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.101.0"
+version = "0.101.1"
 
 include = [
     "Cargo.toml",

--- a/src/der.rs
+++ b/src/der.rs
@@ -225,25 +225,25 @@ const SHORT_FORM_LEN_MAX: u8 = 128;
 const LONG_FORM_LEN_ONE_BYTE: u8 = 0x81;
 
 // Maximum size that can be expressed in a one byte long form len.
-const LONG_FORM_LEN_ONE_BYTE_MAX: usize = (1 << 8) - 1;
+const LONG_FORM_LEN_ONE_BYTE_MAX: usize = 0xff;
 
 // Leading octet for long definite form DER length expressed in subsequent two bytes.
 const LONG_FORM_LEN_TWO_BYTES: u8 = 0x82;
 
 // Maximum size that can be expressed in a two byte long form len.
-const LONG_FORM_LEN_TWO_BYTES_MAX: usize = (1 << (8 * 2)) - 1;
+const LONG_FORM_LEN_TWO_BYTES_MAX: usize = 0xff_ff;
 
 // Leading octet for long definite form DER length expressed in subsequent three bytes.
 const LONG_FORM_LEN_THREE_BYTES: u8 = 0x83;
 
 // Maximum size that can be expressed in a three byte long form len.
-const LONG_FORM_LEN_THREE_BYTES_MAX: usize = (1 << (8 * 3)) - 1;
+const LONG_FORM_LEN_THREE_BYTES_MAX: usize = 0xff_ff_ff;
 
 // Leading octet for long definite form DER length expressed in subsequent four bytes.
 const LONG_FORM_LEN_FOUR_BYTES: u8 = 0x84;
 
 // Maximum size that can be expressed in a four byte long form der len.
-const LONG_FORM_LEN_FOUR_BYTES_MAX: usize = (1 << (8 * 4)) - 1;
+const LONG_FORM_LEN_FOUR_BYTES_MAX: usize = 0xff_ff_ff_ff;
 
 // TODO: investigate taking decoder as a reference to reduce generated code
 // size.


### PR DESCRIPTION
### ci: add a 32bit target build w/ cross.

This commit introduces a CI target that uses [cross](https://github.com/cross-rs/cross) to cross-compile for a ` i686-unknown-linux-gnu` target to ensure we maintain 32bit arch compatibility. Unfortunately I don't believe GitHub actions has a native 32bit runner so cross-compilation is our best bet.

Before applying the subsequent fix commit [this task fails](https://github.com/cpu/webpki/actions/runs/5467843860/jobs/9954676804) with the error reported in #112:
```
   Compiling rustls-webpki v0.101.0 (/home/runner/work/webpki/webpki)
error[E0080]: evaluation of constant value failed
   --> src/der.rs:246:45
    |
246 | const LONG_FORM_LEN_FOUR_BYTES_MAX: usize = (1 << (8 * 4)) - 1;
    |                                             ^^^^^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
```

### der: fix DER max size constants for 32bit targets.

This commit introduces a fix to the `LONG_FORM_LEN_XXX_BYTES_MAX` constants in the `der` module to avoid overflow on 32bit targets.

Resolves #112

### cargo: bump version to 0.101.1
Prepare for a release that includes the 32bit arch fix.