### PR TITLE
ci: iterate on cross CI task.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,8 +195,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo install cross
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: taiki-e/install-action@cross
+
       - run: cross build --target i686-unknown-linux-gnu
 
   coverage:


### PR DESCRIPTION
Quick follow-up to https://github.com/rustls/webpki/pull/113 now that the fire is out.

1. Use [`taiki-e/install-action`](https://github.com/taiki-e/install-action) to get `cross`. In #113 I was worried about introducing new 3rd party actions into the workflows but we're already relying on this 3rd party action to install `cargo llvm-cov` and `cargo deny` and it has support for getting `cross` the same way.
1. Use stable rust. I was seeing build errors w/ `cargo install cross` that were temporarily resolved by using nightly, but this isn't necessary now that we're using the install-action.

This should reduce the additional build time that was introduced with #113 while still maintaining the cross compilation test.
