### PR TITLE
cargo: remove TODO about non-default alloc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ all-features = true
 name = "webpki"
 
 [features]
-# TODO: In the next release, make this non-default.
 default = ["std"]
 alloc = ["ring/alloc"]
 std = ["alloc"]


### PR DESCRIPTION
The Rustls project is the primary motivator for this fork of webpki, and it always uses webpki _with_ alloc. It doesn't seem likely that we'll want to make alloc non-default in the near future, let alone in a next release.