### PR TITLE
ci: match Rustls style, add cargo-semver-checks, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,46 +12,58 @@ on:
 
 jobs:
   rustfmt:
+    name: Format
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
 
-      - run: cargo fmt --all -- --check
+      - name: Check formatting
+        run: cargo fmt --all -- --check
 
   clippy:
+    name: Clippy
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
       - run: cargo clippy --all-features --all-targets
 
   deny:
+    name: Cargo Deny
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-      - uses: taiki-e/install-action@cargo-deny
+      - name: Install cargo deny
+        uses: taiki-e/install-action@cargo-deny
 
       - run: cargo deny check
 
   # Verify that documentation builds.
   rustdoc:
+    name: Check for documentation errors
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -60,29 +72,37 @@ jobs:
           - beta
           - nightly
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@master
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_channel }}
 
-      - run: cargo doc --all-features
+      - name: cargo doc (all features)
+        run: cargo doc --all-features
+
 
   package:
+    name: Cargo Package
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - run: cargo package
 
 
   test:
+    name: Build+test
     runs-on: ${{ matrix.host_os }}
     strategy:
       matrix:
@@ -160,26 +180,32 @@ jobs:
             rust_channel: stable
             host_os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@master
+      - name: Install rust ${{ matrix.rust_channel }} toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_channel }}
 
-      - run: cargo test -vv ${{ matrix.features }} ${{ matrix.mode }}
+      - name: cargo test (${{ matrix.mode }}, ${{ matrix.features }})
+        run: cargo test -vv ${{ matrix.features }} ${{ matrix.mode }}
         env:
           RUSTFLAGS: "-D warnings"
 
   msrv:
+    name: MSRV
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@master
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.60"
       - run: cargo check --lib --all-features
@@ -188,32 +214,41 @@ jobs:
     name: Check cross compilation targets
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-      - uses: taiki-e/install-action@cross
+      - name: Install cross
+        uses: taiki-e/install-action@cross
 
       - run: cross build --target i686-unknown-linux-gnu
 
   coverage:
+    name: Measure coverage
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: llvm-tools
 
-      - run: cargo llvm-cov --all-features --lcov --output-path ./lcov.info
+      - name: Measure coverage
+        run: cargo llvm-cov --all-features --lcov --output-path ./lcov.info
 
-      - uses: codecov/codecov-action@v3
+      - name: Report to codecov.io
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
           files: ./lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
       - name: cargo doc (all features)
         run: cargo doc --all-features
 
-
   package:
     name: Cargo Package
     runs-on: ubuntu-20.04
@@ -99,7 +98,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - run: cargo package
-
 
   test:
     name: Build+test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
 
       - name: cargo doc (all features)
         run: cargo doc --all-features
+        env:
+          RUSTDOCFLAGS: -Dwarnings
 
   package:
     name: Cargo Package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,18 @@ jobs:
 
       - run: cross build --target i686-unknown-linux-gnu
 
+  semver:
+    name: Check semver compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
   coverage:
     name: Measure coverage
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,39 +14,39 @@ jobs:
   rustfmt:
     runs-on: ubuntu-20.04
     steps:
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
 
       - run: cargo fmt --all -- --check
 
   clippy:
     runs-on: ubuntu-20.04
     steps:
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - run: cargo clippy --all-features --all-targets
 
   deny:
     runs-on: ubuntu-20.04
     steps:
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: taiki-e/install-action@cargo-deny
-
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: taiki-e/install-action@cargo-deny
 
       - run: cargo deny check
 
@@ -60,25 +60,24 @@ jobs:
           - beta
           - nightly
     steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_channel }}
 
-      - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-
-      - run: |
-          cargo doc --all-features
+      - run: cargo doc --all-features
 
   package:
     runs-on: ubuntu-20.04
     steps:
-      - uses: dtolnay/rust-toolchain@stable
-
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
 
       - run: cargo package
 
@@ -169,8 +168,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust_channel }}
 
-      - run: |
-          cargo test -vv ${{ matrix.features }} ${{ matrix.mode }}
+      - run: cargo test -vv ${{ matrix.features }} ${{ matrix.mode }}
         env:
           RUSTFLAGS: "-D warnings"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ permissions:
   contents: read
 
 on:
-  pull_request:
   push:
+  pull_request:
   merge_group:
+  schedule:
+    - cron: '0 18 * * *'
 
 jobs:
   rustfmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,16 @@
 name: ci
+
 permissions:
   contents: read
+
 on:
   pull_request:
   push:
   merge_group:
+
 jobs:
   rustfmt:
     runs-on: ubuntu-20.04
-
     steps:
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -22,7 +24,6 @@ jobs:
 
   clippy:
     runs-on: ubuntu-20.04
-
     steps:
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -36,7 +37,6 @@ jobs:
 
   deny:
     runs-on: ubuntu-20.04
-
     steps:
       - uses: dtolnay/rust-toolchain@stable
 
@@ -51,14 +51,12 @@ jobs:
   # Verify that documentation builds.
   rustdoc:
     runs-on: ubuntu-20.04
-
     strategy:
       matrix:
         rust_channel:
           - stable
           - beta
           - nightly
-
     steps:
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -73,7 +71,6 @@ jobs:
 
   package:
     runs-on: ubuntu-20.04
-
     steps:
       - uses: dtolnay/rust-toolchain@stable
 
@@ -86,7 +83,6 @@ jobs:
 
   test:
     runs-on: ${{ matrix.host_os }}
-
     strategy:
       matrix:
         features:
@@ -162,7 +158,6 @@ jobs:
             mode: # debug
             rust_channel: stable
             host_os: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
         with:
@@ -183,6 +178,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.60"

--- a/.github/workflows/testgen.yml
+++ b/.github/workflows/testgen.yml
@@ -1,12 +1,18 @@
 name: Python Testgen
+
 permissions:
   contents: read
+
 on:
   pull_request:
   push:
   merge_group:
+  schedule:
+    - cron: '0 18 * * *'
+
 env:
   PYTHON_VERSION: "3.11"
+
 jobs:
   linting:
     runs-on: ubuntu-latest
@@ -14,42 +20,53 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
+
       - name: Set up Python environment
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip' # caching pip dependencies
+
       - name: Install Python requirements.
         run: pip install -r requirements.txt
+
       - name: flake8 Lint
         uses: py-actions/flake8@v2
+
       - name: mypy Typecheck
         run: mypy ./tests
+
       - name: Black Format
         uses: psf/black@stable
         with:
           src: "./tests"
+
   testgen:
     runs-on: ubuntu-latest
     name: Generate Tests
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
+
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+
       - name: Set up Python environment
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip' # caching pip dependencies
+
       - name: Install Python requirements.
         run: pip install -r requirements.txt
+
       - name: Generate test files
         working-directory: ./tests
         # Generate but don't run the test suite - we already do that in the
         # other CI tasks that run `cargo test`.
         run: python3 generate.py --no-test
+
       - name: Enforce no diff
         run: git diff --exit-code


### PR DESCRIPTION
## Description

In https://github.com/rustls/webpki/pull/115 it was [pointed out](https://github.com/rustls/webpki/pull/115#discussion_r1253867792) that the webpki CI wasn't very consistent with the Rustls repo. In particular the whitespace style differed, and steps weren't being annotated with `name`s.

This branch does a quick standardization pass, and also adds a new `cargo-semver-check` step, tightens up the `cargo doc` step to forbid warnings, adds a cron schedule, and adds a dependabot config.

Probably easiest to review commit-by-commit.

