### PR TITLE
project: increase MSRV, 1.57 -> 1.60

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.57.0
+          toolchain: "1.60"
       - run: cargo check --lib --all-features
 
   cross:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 categories = ["cryptography", "no-std"]
 description = "Web PKI X.509 Certificate Verification."
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ For these tasks you may prefer using webpki in combination with libraries like
 Changelog
 =========
 
+* Next release:
+  - MSRV increased to Rust 1.60.
 * 0.101.1 (2023-07-05)
   - Fixed 32-bit architecture compatibility.
 * 0.101.0 (2023-07-04)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,19 +65,13 @@ pub use {
         SignatureAlgorithm, ECDSA_P256_SHA256, ECDSA_P256_SHA384, ECDSA_P384_SHA256,
         ECDSA_P384_SHA384, ED25519,
     },
+    subject_name::{
+        AddrParseError, DnsNameRef, InvalidDnsNameError, InvalidSubjectNameError, IpAddrRef,
+        SubjectNameRef,
+    },
     time::Time,
     trust_anchor::{TlsClientTrustAnchors, TlsServerTrustAnchors, TrustAnchor},
 };
-
-// TODO(XXX): An interaction between Rust 1.57 and clippy requires working around 'unreachable_pub'
-//            false positives by breaking out these 'pub use' statements individually. Once MSRV
-//            increases they can be collapsed into one as part of the larger 'pub use' above.
-pub use subject_name::AddrParseError;
-pub use subject_name::DnsNameRef;
-pub use subject_name::InvalidDnsNameError;
-pub use subject_name::InvalidSubjectNameError;
-pub use subject_name::IpAddrRef;
-pub use subject_name::SubjectNameRef;
 
 #[cfg(feature = "alloc")]
 pub use {
@@ -87,9 +81,5 @@ pub use {
         RSA_PKCS1_3072_8192_SHA384, RSA_PSS_2048_8192_SHA256_LEGACY_KEY,
         RSA_PSS_2048_8192_SHA384_LEGACY_KEY, RSA_PSS_2048_8192_SHA512_LEGACY_KEY,
     },
-    subject_name::IpAddr,
+    subject_name::{DnsName, IpAddr},
 };
-
-// TODO(XXX): Similar to above, we break this individual 'pub use' for Rust 1.57.
-#[cfg(feature = "alloc")]
-pub use subject_name::DnsName;


### PR DESCRIPTION
### project: increase MSRV, 1.57 -> 1.60
This matches the main Rustls project MSRV (https://github.com/rustls/rustls/pull/1312).

### lib: cleanup Rust 1.57 workaround.
Previously we had to break out some `pub use` statements individually to work around Rust 1.57 clippy false positives for `unreachable_pub`.

Having bumped the MSRV to 1.60 we can remove this workaround.