### PR TITLE
 docs: add attributes indicating req'd features.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: cargo doc (all features)
         run: cargo doc --all-features
         env:
-          RUSTDOCFLAGS: -Dwarnings
+          RUSTDOCFLAGS: ${{ matrix.rust_channel == 'nightly' && '-Dwarnings --cfg=docsrs' || '-Dwarnings' }}
 
   package:
     name: Cargo Package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ include = [
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
 name = "webpki"

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -45,10 +45,9 @@ pub trait CertRevocationList: Sealed {
 
 /// Owned representation of a RFC 5280[^1] profile Certificate Revocation List (CRL).
 ///
-/// This type is only available when using the `alloc` feature.
-///
 /// [^1]: <https://www.rfc-editor.org/rfc/rfc5280#section-5>
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[allow(dead_code)] // we parse some fields we don't expose now, but may choose to expose in the future.
 pub struct OwnedCertRevocationList {
     /// A map of the revoked certificates contained in then CRL, keyed by the DER encoding
@@ -229,9 +228,8 @@ impl<'a> BorrowedCertRevocationList<'a> {
 
     /// Convert the CRL to an [`OwnedCertRevocationList`]. This may error if any of the revoked
     /// certificates in the CRL are malformed or contain unsupported features.
-    ///
-    /// This function is only available when the "alloc" feature is enabled.
     #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_owned(&self) -> Result<OwnedCertRevocationList, Error> {
         // Parse and collect the CRL's revoked cert entries, ensuring there are no errors. With
         // the full set in-hand, create a lookup map by serial number for fast revocation checking.
@@ -423,9 +421,8 @@ pub struct BorrowedRevokedCert<'a> {
 
 impl<'a> BorrowedRevokedCert<'a> {
     /// Construct an owned representation of the revoked certificate.
-    ///
-    /// Only available when the "alloc" feature is enabled.
     #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_owned(&self) -> OwnedRevokedCert {
         OwnedRevokedCert {
             serial_number: self.serial_number.to_vec(),

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -183,10 +183,8 @@ impl<'a> EndEntityCert<'a> {
     /// This function must not be used to implement custom DNS name verification.
     /// Verification functions are already provided as `verify_is_valid_for_dns_name`
     /// and `verify_is_valid_for_at_least_one_dns_name`.
-    ///
-    /// Requires the `alloc` default feature; i.e. this isn't available in
-    /// `#![no_std]` configurations.
     #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn dns_names(&'a self) -> Result<impl Iterator<Item = GeneralDnsNameRef<'a>>, Error> {
         subject_name::list_cert_dns_names(self)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -232,8 +232,8 @@ impl fmt::Display for Error {
     }
 }
 
-/// Requires the `std` feature.
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl ::std::error::Error for Error {}
 
 impl From<untrusted::EndOfInput> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@
     clippy::type_complexity,
     clippy::upper_case_acronyms
 )]
+// Enable documentation for all features on docs.rs
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(any(test, feature = "alloc"))]
 #[cfg_attr(test, macro_use)]

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -18,8 +18,7 @@ use ring::signature;
 /// X.509 certificates and related items that are signed are almost always
 /// encoded in the format "tbs||signatureAlgorithm||signature". This structure
 /// captures this pattern as an owned data type.
-///
-/// This type is only available when the "alloc" feature is enabled.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg(feature = "alloc")]
 pub(crate) struct OwnedSignedData {
     /// The signed data. This would be `tbsCertificate` in the case of an X.509
@@ -77,6 +76,7 @@ pub(crate) struct SignedData<'a> {
 #[cfg(feature = "alloc")]
 impl<'a> SignedData<'a> {
     /// Convert the borrowed signed data to an [`OwnedSignedData`].
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub(crate) fn to_owned(&self) -> OwnedSignedData {
         OwnedSignedData {
             data: self.data.as_slice_less_safe().to_vec(),

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -33,11 +33,12 @@ use crate::Error;
 ///
 /// Requires the `alloc` feature.
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct DnsName(String);
 
-/// Requires the `alloc` feature.
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl DnsName {
     /// Returns a `DnsNameRef` that refers to this `DnsName`.
     pub fn as_ref(&self) -> DnsNameRef {
@@ -45,8 +46,8 @@ impl DnsName {
     }
 }
 
-/// Requires the `alloc` feature.
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl AsRef<str> for DnsName {
     fn as_ref(&self) -> &str {
         self.0.as_ref()
@@ -85,8 +86,8 @@ impl core::fmt::Display for InvalidDnsNameError {
     }
 }
 
-/// Requires the `std` feature.
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl ::std::error::Error for InvalidDnsNameError {}
 
 impl<'a> DnsNameRef<'a> {
@@ -111,9 +112,8 @@ impl<'a> DnsNameRef<'a> {
     }
 
     /// Constructs a `DnsName` from this `DnsNameRef`
-    ///
-    /// Requires the `alloc` feature.
     #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_owned(&self) -> DnsName {
         // DnsNameRef is already guaranteed to be valid ASCII, which is a
         // subset of UTF-8.

--- a/src/subject_name/ip_address.rs
+++ b/src/subject_name/ip_address.rs
@@ -24,6 +24,7 @@ const VALID_IP_BY_CONSTRUCTION: &str = "IP address is a valid string by construc
 
 /// Either a IPv4 or IPv6 address, plus its owned string representation
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum IpAddr {
     /// An IPv4 address and its owned string representation
@@ -33,6 +34,7 @@ pub enum IpAddr {
 }
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl AsRef<str> for IpAddr {
     fn as_ref(&self) -> &str {
         match self {
@@ -51,6 +53,7 @@ pub enum IpAddrRef<'a> {
 }
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a> From<IpAddrRef<'a>> for IpAddr {
     fn from(ip_address: IpAddrRef<'a>) -> IpAddr {
         match ip_address {
@@ -67,6 +70,7 @@ impl<'a> From<IpAddrRef<'a>> for IpAddr {
 }
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a> From<&'a IpAddr> for IpAddrRef<'a> {
     fn from(ip_address: &'a IpAddr) -> IpAddrRef<'a> {
         match ip_address {
@@ -91,8 +95,8 @@ impl core::fmt::Display for AddrParseError {
     }
 }
 
-/// Requires the `std` feature.
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl ::std::error::Error for AddrParseError {}
 
 impl<'a> IpAddrRef<'a> {
@@ -115,9 +119,8 @@ impl<'a> IpAddrRef<'a> {
     }
 
     /// Constructs an `IpAddr` from this `IpAddrRef`
-    ///
-    /// Requires the `alloc` feature.
     #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_owned(&self) -> IpAddr {
         match self {
             IpAddrRef::V4(ip_address, ip_address_octets) => IpAddr::V4(
@@ -152,6 +155,7 @@ fn ipv6_to_uncompressed_string(octets: [u8; 16]) -> String {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<std::net::IpAddr> for IpAddr {
     fn from(ip_address: std::net::IpAddr) -> IpAddr {
         match ip_address {

--- a/src/time.rs
+++ b/src/time.rs
@@ -36,6 +36,7 @@ impl Time {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl TryFrom<std::time::SystemTime> for Time {
     type Error = std::time::SystemTimeError;
 


### PR DESCRIPTION
This branch replaces the convention of calling out required features manually in rustdoc comments with application of cfg attrs that can do the same in a way that rustdoc can pick up and render as a more legible warning.

Resolves https://github.com/rustls/webpki/issues/122