### PR TITLE
clippy fixes, base64 dev-dep 0.13 -> 0.21.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ ring = { version = "0.16.19", default-features = false }
 untrusted = "0.7.1"
 
 [dev-dependencies]
-base64 = "0.13"
+base64 = "0.21"
 bencher = "0.1.5"
 once_cell = "1.17.2"
 rcgen = { version = "0.11.1", default-features = false }

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -73,15 +73,15 @@ fn generate_crl(revoked_count: usize) -> Vec<u8> {
     (0..revoked_count).for_each(|i| {
         revoked_certs.push(RevokedCertParams {
             serial_number: SerialNumber::from((i + 1) as u64),
-            revocation_time: date_time_ymd(2024, 06, 17),
+            revocation_time: date_time_ymd(2024, 6, 17),
             reason_code: Some(RevocationReason::KeyCompromise),
             invalidity_date: None,
         });
     });
 
     let crl = CertificateRevocationListParams {
-        this_update: date_time_ymd(2023, 06, 17),
-        next_update: date_time_ymd(2024, 06, 17),
+        this_update: date_time_ymd(2023, 6, 17),
+        next_update: date_time_ymd(2024, 6, 17),
         crl_number: SerialNumber::from(1234),
         alg: &PKCS_ECDSA_P256_SHA256,
         key_identifier_method: KeyIdMethod::Sha256,

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -49,7 +49,7 @@ fn load_or_generate(crl_path: impl AsRef<Path> + Copy, revoked_count: usize) -> 
         Ok(mut crl_file) => {
             let mut crl_der = Vec::new();
             crl_file.read_to_end(&mut crl_der).unwrap();
-            return crl_der;
+            crl_der
         }
         Err(e) => match e.kind() {
             ErrorKind::NotFound => match File::create(crl_path) {
@@ -57,7 +57,7 @@ fn load_or_generate(crl_path: impl AsRef<Path> + Copy, revoked_count: usize) -> 
                 Ok(mut crl_file) => {
                     let new_crl = generate_crl(revoked_count);
                     crl_file.write_all(&new_crl).unwrap();
-                    return new_crl;
+                    new_crl
                 }
             },
             e => {

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -429,6 +429,8 @@ const ED_25519: AlgorithmIdentifier = AlgorithmIdentifier {
 
 #[cfg(test)]
 mod tests {
+    use base64::{engine::general_purpose, Engine as _};
+
     use crate::{der, signed_data, Error};
     use alloc::{string::String, vec::Vec};
 
@@ -812,7 +814,7 @@ mod tests {
             base64.push_str(line);
         }
 
-        base64::decode(&base64).unwrap()
+        general_purpose::STANDARD.decode(&base64).unwrap()
     }
 
     static SUPPORTED_ALGORITHMS_IN_TESTS: &[&signed_data::SignatureAlgorithm] = &[

--- a/tests/better_tls.rs
+++ b/tests/better_tls.rs
@@ -1,5 +1,4 @@
 use serde::Deserialize;
-use serde_json;
 use std::collections::HashMap;
 use webpki::TrustAnchor;
 

--- a/tests/better_tls.rs
+++ b/tests/better_tls.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose, Engine as _};
 use serde::Deserialize;
 use std::collections::HashMap;
 use webpki::TrustAnchor;
@@ -61,7 +62,9 @@ struct BetterTls {
 
 impl BetterTls {
     fn root_der(&self) -> Vec<u8> {
-        base64::decode(&self.root).expect("invalid trust anchor base64")
+        general_purpose::STANDARD
+            .decode(&self.root)
+            .expect("invalid trust anchor base64")
     }
 }
 
@@ -82,7 +85,11 @@ impl BetterTlsTest {
     fn certs_der(&self) -> Vec<Vec<u8>> {
         self.certificates
             .iter()
-            .map(|cert| base64::decode(cert).expect("invalid cert base64"))
+            .map(|cert| {
+                general_purpose::STANDARD
+                    .decode(cert)
+                    .expect("invalid cert base64")
+            })
             .collect()
     }
 }


### PR DESCRIPTION
Replacement for https://github.com/rustls/webpki/pull/124 that addresses clippy warnings and deprecated base64 fn usage.

### benches: fix decimal constants.
We don't want octal constants here, they're decimal.

### benches: remove unneeded return statements.

Self explanatory.

###  tests: remove unused serde_json import.

Self explanatory.

### deps: base64 0.13 -> 0.21.
This commit updates the `base64` dev-dependency.

Since the old style `base64::decode` is now marked deprecated we also replace these invocations with the engine-based alternatives.