### PR TITLE
crl/signed_data: add Debug and Clone as sensible.

### DIFF
--- a/src/crl.rs
+++ b/src/crl.rs
@@ -49,6 +49,7 @@ pub trait CertRevocationList: Sealed {
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[allow(dead_code)] // we parse some fields we don't expose now, but may choose to expose in the future.
+#[derive(Debug, Clone)]
 pub struct OwnedCertRevocationList {
     /// A map of the revoked certificates contained in then CRL, keyed by the DER encoding
     /// of the revoked cert's serial number.
@@ -94,6 +95,7 @@ impl CertRevocationList for OwnedCertRevocationList {
 /// Borrowed representation of a RFC 5280[^1] profile Certificate Revocation List (CRL).
 ///
 /// [^1]: <https://www.rfc-editor.org/rfc/rfc5280#section-5>
+#[derive(Debug)]
 pub struct BorrowedCertRevocationList<'a> {
     /// A `SignedData` structure that can be passed to `verify_signed_data`.
     signed_data: signed_data::SignedData<'a>,
@@ -345,6 +347,7 @@ impl<'a> IntoIterator for &'a BorrowedCertRevocationList<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct RevokedCerts<'a> {
     reader: untrusted::Reader<'a>,
 }
@@ -364,6 +367,7 @@ impl<'a> Iterator for RevokedCerts<'a> {
 ///
 /// [^1]: <https://www.rfc-editor.org/rfc/rfc5280#section-5>
 #[cfg(feature = "alloc")]
+#[derive(Clone, Debug)]
 pub struct OwnedRevokedCert {
     /// Serial number of the revoked certificate.
     pub serial_number: Vec<u8>,
@@ -400,6 +404,7 @@ impl OwnedRevokedCert {
 /// certificate entry.
 ///
 /// [^1]: <https://www.rfc-editor.org/rfc/rfc5280#section-5>
+#[derive(Debug)]
 pub struct BorrowedRevokedCert<'a> {
     /// Serial number of the revoked certificate.
     pub serial_number: &'a [u8],

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -615,10 +615,39 @@ mod tests {
             let actual = <u8 as TryInto<RevocationReason>>::try_into(*id)
                 .expect("unexpected reason code conversion error");
             assert_eq!(actual, *expected);
+            #[cfg(feature = "alloc")]
+            {
+                // revocation reasons should be Debug.
+                println!("{:?}", actual);
+            }
         }
 
         // Unsupported/unknown revocation reason codes should produce an error.
         let res = <u8 as TryInto<RevocationReason>>::try_into(7);
         assert!(matches!(res, Err(Error::UnsupportedRevocationReason)));
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn test_derived_traits() {
+        let crl = crate::crl::BorrowedCertRevocationList::from_der(include_bytes!(
+            "../tests/crls/crl.valid.der"
+        ))
+        .unwrap();
+        println!("{:?}", crl); // BorrowedCertRevocationList should be debug.
+
+        let owned_crl = crl.to_owned().unwrap();
+        println!("{:?}", owned_crl); // OwnedCertRevocationList should be debug.
+        let _ = owned_crl.clone(); // OwnedCertRevocationList should be clone.
+
+        let mut revoked_certs = crl.into_iter();
+        println!("{:?}", revoked_certs); // RevokedCert should be debug.
+
+        let revoked_cert = revoked_certs.next().unwrap().unwrap();
+        println!("{:?}", revoked_cert); // BorrowedRevokedCert should be debug.
+
+        let owned_revoked_cert = revoked_cert.to_owned();
+        println!("{:?}", owned_revoked_cert); // OwnedRevokedCert should be debug.
+        let _ = owned_revoked_cert.clone(); // OwnedRevokedCert should be clone.
     }
 }

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -20,6 +20,7 @@ use ring::signature;
 /// captures this pattern as an owned data type.
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg(feature = "alloc")]
+#[derive(Clone, Debug)]
 pub(crate) struct OwnedSignedData {
     /// The signed data. This would be `tbsCertificate` in the case of an X.509
     /// certificate, `tbsResponseData` in the case of an OCSP response, `tbsCertList`
@@ -54,6 +55,7 @@ impl OwnedSignedData {
 /// X.509 certificates and related items that are signed are almost always
 /// encoded in the format "tbs||signatureAlgorithm||signature". This structure
 /// captures this pattern.
+#[derive(Debug)]
 pub(crate) struct SignedData<'a> {
     /// The signed data. This would be `tbsCertificate` in the case of an X.509
     /// certificate, `tbsResponseData` in the case of an OCSP response, `tbsCertList`


### PR DESCRIPTION
This branch adds derived `Debug` traits to:

* `BorrowedCertRevocationList`
* `BorrowedRevokedCert`
* `RevokedCerts`
* `SignedData`
* `OwnedCertRevocationList`
* `OwnedRevokedCert`
* `OwnedSignedData`

It additionally adds derived `Clone` traits to:

* `OwnedCertRevocationList`
* `OwnedRevokedCert`
* `OwnedSignedData`