### PR TITLE
Turn free-standing construction functions into associated methods

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -13,8 +13,9 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::der::Tag;
+use crate::signed_data::SignedData;
 use crate::x509::{remember_extension, set_extension_once, Extension};
-use crate::{der, signed_data, Error};
+use crate::{der, Error};
 
 /// An enumeration indicating whether a [`Cert`] is a leaf end-entity cert, or a linked
 /// list node from the CA `Cert` to a child `Cert` it issued.
@@ -31,7 +32,7 @@ pub struct Cert<'a> {
     pub(crate) ee_or_ca: EndEntityOrCa<'a>,
 
     pub(crate) serial: untrusted::Input<'a>,
-    pub(crate) signed_data: signed_data::SignedData<'a>,
+    pub(crate) signed_data: SignedData<'a>,
     pub(crate) issuer: untrusted::Input<'a>,
     pub(crate) validity: untrusted::Input<'a>,
     pub(crate) subject: untrusted::Input<'a>,
@@ -56,7 +57,7 @@ impl<'a> Cert<'a> {
         let (tbs, signed_data) = cert_der.read_all(Error::BadDer, |cert_der| {
             der::nested(cert_der, der::Tag::Sequence, Error::BadDer, |der| {
                 // limited to SEQUENCEs of size 2^16 or less.
-                signed_data::parse_signed_data(der, der::TWO_BYTE_DER_SIZE)
+                SignedData::from_der(der, der::TWO_BYTE_DER_SIZE)
             })
         })?;
 

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -13,8 +13,9 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::der::Tag;
+use crate::signed_data::{self, SignedData};
 use crate::x509::{remember_extension, set_extension_once, Extension};
-use crate::{der, signed_data, Error, SignatureAlgorithm, Time};
+use crate::{der, Error, SignatureAlgorithm, Time};
 
 #[cfg(feature = "alloc")]
 use std::collections::HashMap;
@@ -98,7 +99,7 @@ impl CertRevocationList for OwnedCertRevocationList {
 #[derive(Debug)]
 pub struct BorrowedCertRevocationList<'a> {
     /// A `SignedData` structure that can be passed to `verify_signed_data`.
-    signed_data: signed_data::SignedData<'a>,
+    signed_data: SignedData<'a>,
 
     /// Identifies the entity that has signed and issued this
     /// CRL.
@@ -127,7 +128,7 @@ impl<'a> BorrowedCertRevocationList<'a> {
                 crl_der,
                 Tag::Sequence,
                 Error::BadDer,
-                |signed_der| signed_data::parse_signed_data(signed_der, der::MAX_DER_SIZE),
+                |signed_der| SignedData::from_der(signed_der, der::MAX_DER_SIZE),
                 der::MAX_DER_SIZE,
             )
         })?;

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -62,7 +62,7 @@ impl<'a> TryFrom<&'a [u8]> for EndEntityCert<'a> {
     /// `cert_der`.
     fn try_from(cert_der: &'a [u8]) -> Result<Self, Self::Error> {
         Ok(Self {
-            inner: cert::parse_cert(
+            inner: cert::Cert::from_der(
                 untrusted::Input::from(cert_der),
                 cert::EndEntityOrCa::EndEntity,
             )?,

--- a/src/trust_anchor.rs
+++ b/src/trust_anchor.rs
@@ -1,8 +1,5 @@
-use crate::cert::{lenient_certificate_serial_number, Cert};
-use crate::{
-    cert::{parse_cert, EndEntityOrCa},
-    der, Error,
-};
+use crate::cert::{lenient_certificate_serial_number, Cert, EndEntityOrCa};
+use crate::{der, Error};
 
 /// A trust anchor (a.k.a. root CA).
 ///
@@ -55,7 +52,7 @@ impl<'a> TrustAnchor<'a> {
         // certificate using a special parser for v1 certificates. Notably, that
         // parser doesn't allow extensions, so there's no need to worry about
         // embedded name constraints in a v1 certificate.
-        match parse_cert(cert_der, EndEntityOrCa::EndEntity) {
+        match Cert::from_der(cert_der, EndEntityOrCa::EndEntity) {
             Ok(cert) => Ok(Self::from(cert)),
             Err(Error::UnsupportedCertVersion) => parse_cert_v1(cert_der).or(Err(Error::BadDer)),
             Err(err) => Err(err),

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -13,7 +13,7 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::{
-    cert::{self, Cert, EndEntityOrCa},
+    cert::{Cert, EndEntityOrCa},
     der, signed_data, subject_name, time, CertRevocationList, Error, SignatureAlgorithm,
     TrustAnchor,
 };
@@ -97,7 +97,7 @@ fn build_chain_inner(
 
     loop_while_non_fatal_error(err, opts.intermediate_certs, |cert_der| {
         let potential_issuer =
-            cert::parse_cert(untrusted::Input::from(cert_der), EndEntityOrCa::Ca(cert))?;
+            Cert::from_der(untrusted::Input::from(cert_der), EndEntityOrCa::Ca(cert))?;
 
         if potential_issuer.subject != cert.issuer {
             return Err(Error::UnknownIssuer);


### PR DESCRIPTION
Triggered by reviewing https://github.com/rustls/webpki/pull/127/commits/71cfc964c0245b7252dbc3aeb79ec7c12337e642 -- sorry if this ends up inducing extra rebase work!