### PR TITLE
Prepare release 0.101.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.101.1"
+version = "0.101.2"
 
 include = [
     "Cargo.toml",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Features
   a given DNS name or IP address by considering the allowed usage of the
   certificate and additional constraints.
 
-  
+
 Limitations
 ===============
 
@@ -54,40 +54,7 @@ For these tasks you may prefer using webpki in combination with libraries like
 Changelog
 =========
 
-* Next release:
-  - MSRV increased to Rust 1.60.
-* 0.101.1 (2023-07-05)
-  - Fixed 32-bit architecture compatibility.
-* 0.101.0 (2023-07-04)
-  - *Breaking change*: added `EndEntity::verify_is_valid_tls_client_cert`
-    argument for certificate revocation lists.
-  - *Breaking change*: removed `Time::try_from`.
-  - *Breaking change*: removed `From<DnsNameRef<'_>` impl for `DnsName`.
-  - *Breaking change*: replaced `AsRef<[u8]>` with `AsRef<str>` for `DnsNameRef`.
-  - Added certificate revocation list (CRL) support.
-  - Improved specificity of errors returned from
-    `EndEntityCert::verify_is_valid_tls_client_cert` and
-    `EndEntityCert::verify_is_valid_tls_server_cert`.
-  - Improved error specificity for malformed subject alternate names.
-  - Added `EndEntityCert::dns_names` method for returning a list of DNS subject
-    alternate names from an end entity cert.
-  - Changed `EndEntityCert::verify_is_valid_for_subject_name` to ignore invalid
-    names when verifying cert is valid for a provided subject.
-  - MSRV increased to Rust 1.57.
-* 0.100.1 (2023-03-28)
-  - Relax constraint on serial number length.
-* 0.100.0 (2023-03-13) - first release of `rustls-webpki` crate.
-  - Allow verification of certificates with IP address subjectAltNames.
-    `EndEntityCert::verify_is_valid_for_subject_name` was added, and
-    `EndEntityCert::verify_is_valid_for_dns_name` was removed.
-  - Make `Error` type non-exhaustive.
-  - Reject non-contiguous netmasks in IP address name constraints.
-  - Name constraints of type dNSName and iPAddress now work and are tested.
-    directoryName name constraints are not implemented and will prevent
-    path building where they appear.
-  - Relax requirement that serial numbers are positive to deal with issuers
-    that cannot generate correct ASN.1 but nevertheless persist in doing so.
-* 0.22.0 (2021-04-10) - last upstream release of `webpki` crate.
+Release history can be found [on GitHub](https://github.com/rustls/webpki/releases).
 
 
 Demo


### PR DESCRIPTION
# Proposed release notes

  - MSRV increased to Rust 1.60.
  - Correct bug in CRL processing where certificates with certain forms of serial number were not revocable.
  - Added API for verifying certificate chain with a custom EKU.
  - `TlsServerTrustAnchors`, `TlsClientTrustAnchors`, `verify_is_valid_tls_server_cert` and `verify_is_valid_tls_client_cert` are deprecated: use `verify_for_usage` with `KeyUsage::server_auth()` or `KeyUsage::client_auth()` instead.