### PR TITLE
Name iterator

### DIFF
--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -201,8 +201,24 @@ fn check_presented_id_conforms_to_constraints_in_subtree(
                 dns_name::presented_id_matches_constraint(name, base)
             }
 
-            (GeneralName::DirectoryName(name), GeneralName::DirectoryName(base)) => Ok(
-                presented_directory_name_matches_constraint(name, base, subtrees),
+            (GeneralName::DirectoryName(_), GeneralName::DirectoryName(_)) => Ok(
+                // Reject any uses of directory name constraints; we don't implement this.
+                //
+                // Rejecting everything technically confirms to RFC5280:
+                //
+                //   "If a name constraints extension that is marked as critical imposes constraints
+                //    on a particular name form, and an instance of that name form appears in the
+                //    subject field or subjectAltName extension of a subsequent certificate, then
+                //    the application MUST either process the constraint or _reject the certificate_."
+                //
+                // TODO: rustls/webpki#19
+                //
+                // Rejection is achieved by not matching any PermittedSubtrees, and matching all
+                // ExcludedSubtrees.
+                match subtrees {
+                    Subtrees::PermittedSubtrees => false,
+                    Subtrees::ExcludedSubtrees => true,
+                },
             ),
 
             (GeneralName::IpAddress(name), GeneralName::IpAddress(base)) => {
@@ -255,30 +271,6 @@ fn check_presented_id_conforms_to_constraints_in_subtree(
         Some(Err(Error::NameConstraintViolation))
     } else {
         None
-    }
-}
-
-fn presented_directory_name_matches_constraint(
-    _name: untrusted::Input,
-    _constraint: untrusted::Input,
-    subtrees: Subtrees,
-) -> bool {
-    // Reject any uses of directory name constraints; we don't implement this.
-    //
-    // Rejecting everything technically confirms to RFC5280:
-    //
-    //   "If a name constraints extension that is marked as critical imposes constraints
-    //    on a particular name form, and an instance of that name form appears in the
-    //    subject field or subjectAltName extension of a subsequent certificate, then
-    //    the application MUST either process the constraint or _reject the certificate_."
-    //
-    // TODO: rustls/webpki#19
-    //
-    // Rejection is achieved by not matching any PermittedSubtrees, and matching all
-    // ExcludedSubtrees.
-    match subtrees {
-        Subtrees::PermittedSubtrees => false,
-        Subtrees::ExcludedSubtrees => true,
     }
 }
 

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -160,6 +160,11 @@ fn check_presented_id_conforms_to_constraints(
         (Subtrees::ExcludedSubtrees, excluded_subtrees),
     ];
 
+    fn general_subtree<'b>(input: &mut untrusted::Reader<'b>) -> Result<GeneralName<'b>, Error> {
+        der::expect_tag_and_get_value(input, der::Tag::Sequence)?
+            .read_all(Error::BadDer, GeneralName::from_der)
+    }
+
     for (subtrees, constraints) in subtrees {
         let mut constraints = match constraints {
             Some(constraints) => untrusted::Reader::new(constraints),
@@ -176,13 +181,6 @@ fn check_presented_id_conforms_to_constraints(
             // Since the default value isn't allowed to be encoded according to the
             // DER encoding rules for DEFAULT, this is equivalent to saying that
             // neither minimum or maximum must be encoded.
-            fn general_subtree<'b>(
-                input: &mut untrusted::Reader<'b>,
-            ) -> Result<GeneralName<'b>, Error> {
-                let general_subtree = der::expect_tag_and_get_value(input, der::Tag::Sequence)?;
-                general_subtree.read_all(Error::BadDer, GeneralName::from_der)
-            }
-
             let base = match general_subtree(&mut constraints) {
                 Ok(base) => base,
                 Err(err) => return Some(Err(err)),


### PR DESCRIPTION
This makes the abstractions a lot more intuitive/idiomatic in my opinion.

I think it has the potential to bring `list_cert_dns_names()` out of the `alloc` domain (see #46), but that would be at the cost of making it yield an `impl Iterator<Item = Result<GeneralName<'_>, Error>>` rather than a `Result<impl Iterator<Item = GeneralName<'_>>, Error>` which might be undesirable?