### PR TITLE
Refactor DER parsing

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -37,7 +37,7 @@ pub struct Cert<'a> {
     pub(crate) issuer: untrusted::Input<'a>,
     pub(crate) validity: untrusted::Input<'a>,
     pub(crate) subject: untrusted::Input<'a>,
-    pub(crate) spki: der::Value<'a>,
+    pub(crate) spki: untrusted::Input<'a>,
 
     pub(crate) basic_constraints: Option<untrusted::Input<'a>>,
     // key usage (KU) extension (if any). When validating certificate revocation lists (CRLs) this

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -68,7 +68,7 @@ impl<'a> Cert<'a> {
 
             let serial = lenient_certificate_serial_number(tbs)?;
 
-            let signature = der::expect_tag_and_get_value(tbs, der::Tag::Sequence)?;
+            let signature = der::expect_tag(tbs, der::Tag::Sequence)?;
             // TODO: In mozilla::pkix, the comparison is done based on the
             // normalized value (ignoring whether or not there is an optional NULL
             // parameter for RSA-based algorithms), so this may be too strict.
@@ -76,9 +76,9 @@ impl<'a> Cert<'a> {
                 return Err(Error::SignatureAlgorithmMismatch);
             }
 
-            let issuer = der::expect_tag_and_get_value(tbs, der::Tag::Sequence)?;
-            let validity = der::expect_tag_and_get_value(tbs, der::Tag::Sequence)?;
-            let subject = der::expect_tag_and_get_value(tbs, der::Tag::Sequence)?;
+            let issuer = der::expect_tag(tbs, der::Tag::Sequence)?;
+            let validity = der::expect_tag(tbs, der::Tag::Sequence)?;
+            let subject = der::expect_tag(tbs, der::Tag::Sequence)?;
             let spki = der::expect_tag(tbs, der::Tag::Sequence)?;
 
             // In theory there could be fields [1] issuerUniqueID and [2]
@@ -188,7 +188,7 @@ pub(crate) fn lenient_certificate_serial_number<'a>(
     //   Note: Non-conforming CAs may issue certificates with serial numbers
     //   that are negative or zero.  Certificate users SHOULD be prepared to
     //   gracefully handle such certificates.
-    der::expect_tag_and_get_value(input, Tag::Integer)
+    der::expect_tag(input, Tag::Integer)
 }
 
 fn remember_cert_extension<'a>(
@@ -229,7 +229,7 @@ fn remember_cert_extension<'a>(
                 // read the raw bytes here and parse at the time of use.
                 15 => Ok(value.read_bytes_to_end()),
                 // All other remembered certificate extensions are wrapped in a Sequence.
-                _ => der::expect_tag_and_get_value(value, Tag::Sequence),
+                _ => der::expect_tag(value, Tag::Sequence),
             })
         })
     })

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -283,14 +283,14 @@ impl<'a> FromDer<'a> for BorrowedCertRevocationList<'a> {
             // RFC 5280 §5.1.2.2:
             //   This field MUST contain the same algorithm identifier as the
             //   signatureAlgorithm field in the sequence CertificateList
-            let signature = der::expect_tag_and_get_value(tbs_cert_list, Tag::Sequence)?;
+            let signature = der::expect_tag(tbs_cert_list, Tag::Sequence)?;
             if signature != signed_data.algorithm {
                 return Err(Error::SignatureAlgorithmMismatch);
             }
 
             // RFC 5280 §5.1.2.3:
             //   The issuer field MUST contain a non-empty X.500 distinguished name (DN).
-            let issuer = der::expect_tag_and_get_value(tbs_cert_list, Tag::Sequence)?;
+            let issuer = der::expect_tag(tbs_cert_list, Tag::Sequence)?;
 
             // RFC 5280 §5.1.2.4:
             //    This field indicates the issue date of this CRL.  thisUpdate may be
@@ -519,7 +519,7 @@ impl<'a> FromDer<'a> for BorrowedRevokedCert<'a> {
             // It would be convenient to use der::nested_of_mut here to unpack a SEQUENCE of one or
             // more SEQUENCEs, however CAs have been mis-encoding the absence of extensions as an
             // empty SEQUENCE so we must be tolerant of that.
-            let ext_seq = der::expect_tag_and_get_value(der, Tag::Sequence)?;
+            let ext_seq = der::expect_tag(der, Tag::Sequence)?;
             if ext_seq.is_empty() {
                 return Ok(revoked_cert);
             }

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -133,8 +133,7 @@ impl<'a> BorrowedCertRevocationList<'a> {
     ///
     /// [^1]: <https://www.rfc-editor.org/rfc/rfc5280#section-5>
     pub fn from_der(crl_der: &'a [u8]) -> Result<Self, Error> {
-        let input = untrusted::Input::from(crl_der);
-        input.read_all(Error::BadDer, <Self as FromDer>::from_der)
+        der::read_all(untrusted::Input::from(crl_der))
     }
 
     /// Convert the CRL to an [`OwnedCertRevocationList`]. This may error if any of the revoked
@@ -460,11 +459,7 @@ impl<'a> BorrowedRevokedCert<'a> {
         remember_extension(extension, |id| {
             match id {
                 // id-ce-cRLReasons 2.5.29.21 - RFC 5280 §5.3.1.
-                21 => set_extension_once(&mut self.reason_code, || {
-                    extension
-                        .value
-                        .read_all(Error::BadDer, RevocationReason::from_der)
-                }),
+                21 => set_extension_once(&mut self.reason_code, || der::read_all(extension.value)),
 
                 // id-ce-invalidityDate 2.5.29.24 - RFC 5280 §5.3.2.
                 24 => set_extension_once(&mut self.invalidity_date, || {

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -590,8 +590,8 @@ impl RevocationReason {
 impl<'a> FromDer<'a> for RevocationReason {
     // RFC 5280 §5.3.1.
     fn from_der(reader: &mut untrusted::Reader<'a>) -> Result<Self, Error> {
-        let value = der::expect_tag(reader, Tag::Enum)?;
-        Self::try_from(value.value().read_all(Error::BadDer, |reason| {
+        let input = der::expect_tag(reader, Tag::Enum)?;
+        Self::try_from(input.read_all(Error::BadDer, |reason| {
             reason.read_byte().map_err(|_| Error::BadDer)
         })?)
     }

--- a/src/der.rs
+++ b/src/der.rs
@@ -94,7 +94,7 @@ pub(crate) fn expect_tag_and_get_value<'a>(
     input: &mut untrusted::Reader<'a>,
     tag: Tag,
 ) -> Result<untrusted::Input<'a>, Error> {
-    let (actual_tag, inner) = read_tag_and_get_value(input)?;
+    let (actual_tag, inner) = read_tag_and_get_value_limited(input, TWO_BYTE_DER_SIZE)?;
     if usize::from(tag) != usize::from(actual_tag) {
         return Err(Error::BadDer);
     }
@@ -141,7 +141,7 @@ pub(crate) fn expect_tag<'a>(
     input: &mut untrusted::Reader<'a>,
     tag: Tag,
 ) -> Result<untrusted::Input<'a>, Error> {
-    let (actual_tag, value) = read_tag_and_get_value(input)?;
+    let (actual_tag, value) = read_tag_and_get_value_limited(input, TWO_BYTE_DER_SIZE)?;
     if usize::from(tag) != usize::from(actual_tag) {
         return Err(Error::BadDer);
     }

--- a/src/der.rs
+++ b/src/der.rs
@@ -137,26 +137,16 @@ pub(crate) fn nested<'a, R, E: Copy>(
     nested_limited(input, tag, error, decoder, TWO_BYTE_DER_SIZE)
 }
 
-pub(crate) struct Value<'a> {
-    value: untrusted::Input<'a>,
-}
-
-impl<'a> Value<'a> {
-    pub(crate) fn value(&self) -> untrusted::Input<'a> {
-        self.value
-    }
-}
-
 pub(crate) fn expect_tag<'a>(
     input: &mut untrusted::Reader<'a>,
     tag: Tag,
-) -> Result<Value<'a>, Error> {
+) -> Result<untrusted::Input<'a>, Error> {
     let (actual_tag, value) = read_tag_and_get_value(input)?;
     if usize::from(tag) != usize::from(actual_tag) {
         return Err(Error::BadDer);
     }
 
-    Ok(Value { value })
+    Ok(value)
 }
 
 #[inline(always)]

--- a/src/der.rs
+++ b/src/der.rs
@@ -90,18 +90,6 @@ impl From<Tag> for u8 {
 }
 
 #[inline(always)]
-pub(crate) fn expect_tag_and_get_value<'a>(
-    input: &mut untrusted::Reader<'a>,
-    tag: Tag,
-) -> Result<untrusted::Input<'a>, Error> {
-    let (actual_tag, inner) = read_tag_and_get_value_limited(input, TWO_BYTE_DER_SIZE)?;
-    if usize::from(tag) != usize::from(actual_tag) {
-        return Err(Error::BadDer);
-    }
-    Ok(inner)
-}
-
-#[inline(always)]
 pub(crate) fn expect_tag_and_get_value_limited<'a>(
     input: &mut untrusted::Reader<'a>,
     tag: Tag,
@@ -370,7 +358,7 @@ impl<'a> FromDer<'a> for u8 {
 pub(crate) fn nonnegative_integer<'a>(
     input: &mut untrusted::Reader<'a>,
 ) -> Result<untrusted::Input<'a>, Error> {
-    let value = expect_tag_and_get_value(input, Tag::Integer)?;
+    let value = expect_tag(input, Tag::Integer)?;
     match value
         .as_slice_less_safe()
         .split_first()

--- a/src/der.rs
+++ b/src/der.rs
@@ -45,6 +45,10 @@ pub(crate) trait FromDer<'a>: Sized + 'a {
     fn from_der(reader: &mut untrusted::Reader<'a>) -> Result<Self, Error>;
 }
 
+pub(crate) fn read_all<'a, T: FromDer<'a>>(input: untrusted::Input<'a>) -> Result<T, Error> {
+    input.read_all(Error::BadDer, T::from_der)
+}
+
 // Copied (and extended) from ring's src/der.rs
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Copy, Eq, PartialEq)]

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -147,7 +147,7 @@ impl<'a> EndEntityCert<'a> {
     ) -> Result<(), Error> {
         signed_data::verify_signature(
             signature_alg,
-            self.inner.spki.value(),
+            self.inner.spki,
             untrusted::Input::from(msg),
             untrusted::Input::from(signature),
         )

--- a/src/error.rs
+++ b/src/error.rs
@@ -107,6 +107,9 @@ pub enum Error {
     /// does not match the algorithm in the signature of the certificate.
     SignatureAlgorithmMismatch,
 
+    /// Trailing data was found while parsing DER-encoded input for the named type.
+    TrailingData(DerTypeId),
+
     /// A valid issuer for the certificate could not be found.
     UnknownIssuer,
 
@@ -222,7 +225,7 @@ impl Error {
             // Errors related to malformed data.
             Error::MalformedDnsIdentifier => 6,
             Error::MalformedNameConstraint => 5,
-            Error::MalformedExtensions => 4,
+            Error::MalformedExtensions | Error::TrailingData(_) => 4,
             Error::ExtensionValueInvalid => 3,
 
             // Generic DER errors.
@@ -249,4 +252,37 @@ impl From<untrusted::EndOfInput> for Error {
     fn from(_: untrusted::EndOfInput) -> Self {
         Error::BadDer
     }
+}
+
+/// Trailing data was found while parsing DER-encoded input for the named type.
+#[allow(missing_docs)]
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DerTypeId {
+    BitString,
+    Bool,
+    Certificate,
+    CertificateExtensions,
+    CertificateTbsCertificate,
+    CertRevocationList,
+    CertRevocationListExtension,
+    CrlDistributionPoint,
+    CommonNameInner,
+    CommonNameOuter,
+    DistributionPointName,
+    Extension,
+    GeneralName,
+    RevocationReason,
+    Signature,
+    SignatureAlgorithm,
+    SignedData,
+    SubjectPublicKeyInfo,
+    Time,
+    TrustAnchorV1,
+    TrustAnchorV1TbsCertificate,
+    U8,
+    RevokedCertificate,
+    RevokedCertificateExtension,
+    RevokedCertEntry,
+    IssuingDistributionPoint,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub use {
     cert::{Cert, EndEntityOrCa},
     crl::{BorrowedCertRevocationList, BorrowedRevokedCert, CertRevocationList, RevocationReason},
     end_entity::EndEntityCert,
-    error::Error,
+    error::{DerTypeId, Error},
     signed_data::{alg_id, InvalidSignature, SignatureVerificationAlgorithm},
     subject_name::{
         AddrParseError, DnsNameRef, InvalidDnsNameError, InvalidSubjectNameError, IpAddrRef,

--- a/src/ring_algs.rs
+++ b/src/ring_algs.rs
@@ -192,7 +192,7 @@ mod tests {
         let spki_value = untrusted::Input::from(&tsd.spki);
         let spki_value = spki_value
             .read_all(Error::BadDer, |input| {
-                der::expect_tag_and_get_value(input, der::Tag::Sequence)
+                der::expect_tag(input, der::Tag::Sequence)
             })
             .unwrap();
 
@@ -205,7 +205,7 @@ mod tests {
         let algorithm = untrusted::Input::from(&tsd.algorithm);
         let algorithm = algorithm
             .read_all(Error::BadDer, |input| {
-                der::expect_tag_and_get_value(input, der::Tag::Sequence)
+                der::expect_tag(input, der::Tag::Sequence)
             })
             .unwrap();
 
@@ -272,7 +272,7 @@ mod tests {
         assert_eq!(
             Err(expected_error),
             spki.read_all(Error::BadDer, |input| {
-                der::expect_tag_and_get_value(input, der::Tag::Sequence)
+                der::expect_tag(input, der::Tag::Sequence)
             })
         );
     }

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -206,7 +206,7 @@ pub(crate) fn verify_signature(
     msg: untrusted::Input,
     signature: untrusted::Input,
 ) -> Result<(), Error> {
-    let spki = spki_value.read_all(Error::BadDer, SubjectPublicKeyInfo::from_der)?;
+    let spki = der::read_all::<SubjectPublicKeyInfo>(spki_value)?;
     if !signature_alg
         .public_key_alg_id()
         .matches_algorithm_id_value(spki.algorithm_id_value)

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -13,7 +13,7 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::der::{self, FromDer};
-use crate::error::Error;
+use crate::error::{DerTypeId, Error};
 
 /// X.509 certificates and related items that are signed are almost always
 /// encoded in the format "tbs||signatureAlgorithm||signature". This structure
@@ -241,6 +241,8 @@ impl<'a> FromDer<'a> for SubjectPublicKeyInfo<'a> {
             key_value,
         })
     }
+
+    const TYPE_ID: DerTypeId = DerTypeId::SubjectPublicKeyInfo;
 }
 
 /// An abstract signature verification algorithm.

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -114,7 +114,7 @@ impl<'a> SignedData<'a> {
         let (data, tbs) = der.read_partial(|input| {
             der::expect_tag_and_get_value_limited(input, der::Tag::Sequence, size_limit)
         })?;
-        let algorithm = der::expect_tag_and_get_value(der, der::Tag::Sequence)?;
+        let algorithm = der::expect_tag(der, der::Tag::Sequence)?;
         let signature = der::bit_string_with_no_unused_bits(der)?;
 
         Ok((
@@ -234,7 +234,7 @@ impl<'a> FromDer<'a> for SubjectPublicKeyInfo<'a> {
     // `PublicKeyAlgorithm` for the `SignatureVerificationAlgorithm` that is matched when
     // parsing the signature.
     fn from_der(reader: &mut untrusted::Reader<'a>) -> Result<Self, Error> {
-        let algorithm_id_value = der::expect_tag_and_get_value(reader, der::Tag::Sequence)?;
+        let algorithm_id_value = der::expect_tag(reader, der::Tag::Sequence)?;
         let key_value = der::bit_string_with_no_unused_bits(reader)?;
         Ok(SubjectPublicKeyInfo {
             algorithm_id_value,

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -113,7 +113,7 @@ pub(crate) fn check_name_constraints(
         if !inner.peek(subtrees_tag.into()) {
             return Ok(None);
         }
-        der::expect_tag_and_get_value(inner, subtrees_tag).map(Some)
+        der::expect_tag(inner, subtrees_tag).map(Some)
     }
 
     let permitted_subtrees = parse_subtrees(input, der::Tag::ContextSpecificConstructed0)?;
@@ -161,7 +161,7 @@ fn check_presented_id_conforms_to_constraints(
     ];
 
     fn general_subtree<'b>(input: &mut untrusted::Reader<'b>) -> Result<GeneralName<'b>, Error> {
-        der::read_all(der::expect_tag_and_get_value(input, der::Tag::Sequence)?)
+        der::read_all(der::expect_tag(input, der::Tag::Sequence)?)
     }
 
     for (subtrees, constraints) in subtrees {
@@ -451,9 +451,9 @@ fn common_name(input: untrusted::Input) -> Result<Option<untrusted::Input>, Erro
     der::nested(inner, der::Tag::Set, Error::BadDer, |tagged| {
         der::nested(tagged, der::Tag::Sequence, Error::BadDer, |tagged| {
             while !tagged.at_end() {
-                let name_oid = der::expect_tag_and_get_value(tagged, der::Tag::OID)?;
+                let name_oid = der::expect_tag(tagged, der::Tag::OID)?;
                 if name_oid == COMMON_NAME {
-                    return der::expect_tag_and_get_value(tagged, der::Tag::UTF8String).map(Some);
+                    return der::expect_tag(tagged, der::Tag::UTF8String).map(Some);
                 } else {
                     // discard unused name value
                     der::read_tag_and_get_value(tagged)?;

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -161,8 +161,7 @@ fn check_presented_id_conforms_to_constraints(
     ];
 
     fn general_subtree<'b>(input: &mut untrusted::Reader<'b>) -> Result<GeneralName<'b>, Error> {
-        der::expect_tag_and_get_value(input, der::Tag::Sequence)?
-            .read_all(Error::BadDer, GeneralName::from_der)
+        der::read_all(der::expect_tag_and_get_value(input, der::Tag::Sequence)?)
     }
 
     for (subtrees, constraints) in subtrees {

--- a/src/trust_anchor.rs
+++ b/src/trust_anchor.rs
@@ -61,8 +61,8 @@ impl<'a> TrustAnchor<'a> {
                     skip(tbs, der::Tag::Sequence)?; // signature.
                     skip(tbs, der::Tag::Sequence)?; // issuer.
                     skip(tbs, der::Tag::Sequence)?; // validity.
-                    let subject = der::expect_tag_and_get_value(tbs, der::Tag::Sequence)?;
-                    let spki = der::expect_tag_and_get_value(tbs, der::Tag::Sequence)?;
+                    let subject = der::expect_tag(tbs, der::Tag::Sequence)?;
+                    let spki = der::expect_tag(tbs, der::Tag::Sequence)?;
 
                     Ok(TrustAnchor {
                         subject: subject.as_slice_less_safe(),
@@ -92,5 +92,5 @@ impl<'a> From<Cert<'a>> for TrustAnchor<'a> {
 }
 
 fn skip(input: &mut untrusted::Reader, tag: der::Tag) -> Result<(), Error> {
-    der::expect_tag_and_get_value(input, tag).map(|_| ())
+    der::expect_tag(input, tag).map(|_| ())
 }

--- a/src/trust_anchor.rs
+++ b/src/trust_anchor.rs
@@ -85,7 +85,7 @@ impl<'a> From<Cert<'a>> for TrustAnchor<'a> {
     fn from(cert: Cert<'a>) -> Self {
         Self {
             subject: cert.subject.as_slice_less_safe(),
-            spki: cert.spki.value().as_slice_less_safe(),
+            spki: cert.spki.as_slice_less_safe(),
             name_constraints: cert.name_constraints.map(|nc| nc.as_slice_less_safe()),
         }
     }

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -110,9 +110,7 @@ fn build_chain_inner(
         // Prevent loops; see RFC 4158 section 5.2.
         let mut prev = cert;
         loop {
-            if potential_issuer.spki.value() == prev.spki.value()
-                && potential_issuer.subject == prev.subject
-            {
+            if potential_issuer.spki == prev.spki && potential_issuer.subject == prev.subject {
                 return Err(Error::UnknownIssuer);
             }
             match &prev.ee_or_ca {
@@ -164,7 +162,7 @@ fn check_signatures(
 
         match &cert.ee_or_ca {
             EndEntityOrCa::Ca(child_cert) => {
-                spki_value = cert.spki.value();
+                spki_value = cert.spki;
                 issuer_subject = cert.subject;
                 issuer_key_usage = cert.key_usage;
                 cert = child_cert;

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -395,7 +395,7 @@ impl ExtendedKeyUsage {
         };
 
         loop {
-            let value = der::expect_tag_and_get_value(input, der::Tag::OID)?;
+            let value = der::expect_tag(input, der::Tag::OID)?;
             if self.key_purpose_id_equals(value) {
                 input.skip_to_end();
                 break;
@@ -464,10 +464,9 @@ impl KeyUsageMode {
     // https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.3
     fn check(self, input: Option<untrusted::Input>) -> Result<(), Error> {
         let bit_string = match input {
-            Some(input) => der::expect_tag_and_get_value(
-                &mut untrusted::Reader::new(input),
-                der::Tag::BitString,
-            )?,
+            Some(input) => {
+                der::expect_tag(&mut untrusted::Reader::new(input), der::Tag::BitString)?
+            }
             // While RFC 5280 requires KeyUsage be present, historically the absence of a KeyUsage
             // has been treated as "Any Usage". We follow that convention here and assume the absence
             // of KeyUsage implies the required_ku_bit_if_present we're checking for.

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -13,8 +13,8 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::der::{self, DerIterator, FromDer, CONSTRUCTED, CONTEXT_SPECIFIC};
+use crate::error::{DerTypeId, Error};
 use crate::subject_name::GeneralName;
-use crate::Error;
 
 pub(crate) struct Extension<'a> {
     pub(crate) critical: bool,
@@ -42,6 +42,8 @@ impl<'a> FromDer<'a> for Extension<'a> {
             value,
         })
     }
+
+    const TYPE_ID: DerTypeId = DerTypeId::Extension;
 }
 
 pub(crate) fn set_extension_once<T>(
@@ -107,4 +109,6 @@ impl<'a> FromDer<'a> for DistributionPointName<'a> {
             _ => Err(Error::BadDer),
         }
     }
+
+    const TYPE_ID: DerTypeId = DerTypeId::DistributionPointName;
 }

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -33,9 +33,9 @@ impl<'a> Extension<'a> {
 
 impl<'a> FromDer<'a> for Extension<'a> {
     fn from_der(reader: &mut untrusted::Reader<'a>) -> Result<Self, Error> {
-        let id = der::expect_tag_and_get_value(reader, der::Tag::OID)?;
+        let id = der::expect_tag(reader, der::Tag::OID)?;
         let critical = bool::from_der(reader)?;
-        let value = der::expect_tag_and_get_value(reader, der::Tag::OctetString)?;
+        let value = der::expect_tag(reader, der::Tag::OctetString)?;
         Ok(Extension {
             id,
             critical,

--- a/tests/crl_tests.rs
+++ b/tests/crl_tests.rs
@@ -1,4 +1,4 @@
-use webpki::{BorrowedCertRevocationList, CertRevocationList, Error};
+use webpki::{BorrowedCertRevocationList, CertRevocationList, DerTypeId, Error};
 
 const REVOKED_SERIAL: &[u8] = &[0x03, 0xAE, 0x51, 0xDB, 0x51, 0x15, 0x5A, 0x3C];
 
@@ -59,7 +59,7 @@ fn parse_missing_next_update_crl() {
     // Parsing a CRL with a missing next update time should error.
     let crl = include_bytes!("crls/crl.missing.next.update.der");
     let res = BorrowedCertRevocationList::from_der(&crl[..]);
-    assert!(matches!(res, Err(Error::BadDer)));
+    assert!(matches!(res, Err(Error::TrailingData(DerTypeId::Time))));
 }
 
 #[test]


### PR DESCRIPTION
Now that we no longer depend on generic *ring* things, there is a bunch of stuff we can do to simplify DER handling.