### PR TITLE
fix no-std support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,3 +266,29 @@ jobs:
           files: ./lcov.info
           fail_ci_if_error: true
           verbose: true
+
+  nostd:
+    name: Verify that no-std modes do not rely on libstd
+    runs-on: ubuntu-20.04
+    # a target without a pre-compiled libstd like this one will catch any use of libstd in the
+    # entire dependency graph whereas a target like x86_64-unknown-linux-gnu will not
+    env:
+      NOSTD_TARGET: x86_64-unknown-none
+    strategy:
+      matrix:
+        features:
+          - --no-default-features
+          - --no-default-features --features alloc
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: "$NOSTD_TARGET"
+
+      - name: check no-std mode
+        run: cargo check --target $NOSTD_TARGET ${{ matrix.features  }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ name = "webpki"
 [features]
 default = ["std", "ring"]
 ring = ["dep:ring"]
-alloc = ["ring/alloc"]
+alloc = ["ring?/alloc"]
 std = ["alloc"]
 
 [dependencies]

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -19,7 +19,9 @@ use crate::x509::{remember_extension, set_extension_once, DistributionPointName,
 use crate::{Error, SignatureVerificationAlgorithm, Time};
 
 #[cfg(feature = "alloc")]
-use std::collections::HashMap;
+use alloc::collections::BTreeMap;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use private::Sealed;
 
@@ -57,7 +59,7 @@ pub trait CertRevocationList: Sealed {
 pub struct OwnedCertRevocationList {
     /// A map of the revoked certificates contained in then CRL, keyed by the DER encoding
     /// of the revoked cert's serial number.
-    revoked_certs: HashMap<Vec<u8>, OwnedRevokedCert>,
+    revoked_certs: BTreeMap<Vec<u8>, OwnedRevokedCert>,
 
     issuer: Vec<u8>,
 
@@ -149,7 +151,7 @@ impl<'a> BorrowedCertRevocationList<'a> {
             .collect::<Result<Vec<_>, _>>()?
             .iter()
             .map(|revoked_cert| (revoked_cert.serial_number.to_vec(), revoked_cert.to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
 
         Ok(OwnedCertRevocationList {
             signed_data: self.signed_data.to_owned(),

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -15,6 +15,9 @@
 use crate::der::{self, FromDer};
 use crate::error::Error;
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 /// X.509 certificates and related items that are signed are almost always
 /// encoded in the format "tbs||signatureAlgorithm||signature". This structure
 /// captures this pattern as an owned data type.


### PR DESCRIPTION
this PR
- makes the `alloc` feature not pull in the optional `ring` dependency
- fixes `cargo build --no-default-features --features alloc`
- adds a CI check to prevent no-std support breaking in the future

fixes #143 
fixes #144 