### PR TITLE
Switch to using the pki-types crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,11 @@ name = "webpki"
 [features]
 default = ["std", "ring"]
 ring = ["dep:ring"]
-alloc = ["ring?/alloc"]
+alloc = ["ring?/alloc", "pki-types/alloc"]
 std = ["alloc"]
 
 [dependencies]
+pki-types = { package = "rustls-pki-types", version = "0.1", default-features = false }
 ring = { version = "0.16.19", default-features = false, optional = true }
 untrusted = "0.7.1"
 

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -12,11 +12,13 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use pki_types::{CertificateDer, TrustAnchor};
+
 #[cfg(feature = "alloc")]
 use crate::subject_name::GeneralDnsNameRef;
 use crate::{
     cert, signed_data, subject_name, verify_cert, Error, KeyUsage, RevocationOptions,
-    SignatureVerificationAlgorithm, SubjectNameRef, Time, TrustAnchor,
+    SignatureVerificationAlgorithm, SubjectNameRef, Time,
 };
 
 /// An end-entity certificate.
@@ -54,15 +56,15 @@ pub struct EndEntityCert<'a> {
     inner: cert::Cert<'a>,
 }
 
-impl<'a> TryFrom<&'a [u8]> for EndEntityCert<'a> {
+impl<'a> TryFrom<&'a CertificateDer<'a>> for EndEntityCert<'a> {
     type Error = Error;
 
     /// Parse the ASN.1 DER-encoded X.509 encoding of the certificate
     /// `cert_der`.
-    fn try_from(cert_der: &'a [u8]) -> Result<Self, Self::Error> {
+    fn try_from(cert: &'a CertificateDer<'a>) -> Result<Self, Self::Error> {
         Ok(Self {
             inner: cert::Cert::from_der(
-                untrusted::Input::from(cert_der),
+                untrusted::Input::from(cert.as_ref()),
                 cert::EndEntityOrCa::EndEntity,
             )?,
         })
@@ -93,7 +95,7 @@ impl<'a> EndEntityCert<'a> {
         &self,
         supported_sig_algs: &[&dyn SignatureVerificationAlgorithm],
         trust_anchors: &[TrustAnchor],
-        intermediate_certs: &[&[u8]],
+        intermediate_certs: &[CertificateDer<'_>],
         time: Time,
         usage: KeyUsage,
         revocation: Option<RevocationOptions>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,13 +71,16 @@ pub use {
         SubjectNameRef,
     },
     time::Time,
-    trust_anchor::TrustAnchor,
+    trust_anchor::extract_trust_anchor,
     verify_cert::{
         KeyUsage, RevocationCheckDepth, RevocationOptions, RevocationOptionsBuilder,
         UnknownStatusPolicy,
     },
 };
 
+pub use pki_types as types;
+
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg(feature = "alloc")]
 pub use {
     crl::{OwnedCertRevocationList, OwnedRevokedCert},

--- a/src/trust_anchor.rs
+++ b/src/trust_anchor.rs
@@ -1,103 +1,85 @@
+use pki_types::{CertificateDer, TrustAnchor};
+
 use crate::cert::{lenient_certificate_serial_number, Cert, EndEntityOrCa};
 use crate::der;
 use crate::error::{DerTypeId, Error};
 
-/// A trust anchor (a.k.a. root CA).
-///
-/// Traditionally, certificate verification libraries have represented trust
-/// anchors as full X.509 root certificates. However, those certificates
-/// contain a lot more data than is needed for verifying certificates. The
-/// `TrustAnchor` representation allows an application to store just the
-/// essential elements of trust anchors. The `TrustAnchor::try_from_cert_der`
-/// function allows converting X.509 certificates to to the minimized
-/// `TrustAnchor` representation, either at runtime or in a build script.
-#[derive(Debug)]
-pub struct TrustAnchor<'a> {
-    /// The value of the `subject` field of the trust anchor.
-    pub subject: &'a [u8],
+/// Interprets the given DER-encoded certificate as a `TrustAnchor`. The
+/// certificate is not validated. In particular, there is no check that the
+/// certificate is self-signed or even that the certificate has the cA basic
+/// constraint.
+pub fn extract_trust_anchor<'a>(cert: &'a CertificateDer<'a>) -> Result<TrustAnchor<'a>, Error> {
+    let cert_der = untrusted::Input::from(cert.as_ref());
 
-    /// The value of the `subjectPublicKeyInfo` field of the trust anchor.
-    pub spki: &'a [u8],
-
-    /// The value of a DER-encoded NameConstraints, containing name
-    /// constraints to apply to the trust anchor, if any.
-    pub name_constraints: Option<&'a [u8]>,
+    // XXX: `EndEntityOrCA::EndEntity` is used instead of `EndEntityOrCA::CA`
+    // because we don't have a reference to a child cert, which is needed for
+    // `EndEntityOrCA::CA`. For this purpose, it doesn't matter.
+    //
+    // v1 certificates will result in `Error::BadDer` because `parse_cert` will
+    // expect a version field that isn't there. In that case, try to parse the
+    // certificate using a special parser for v1 certificates. Notably, that
+    // parser doesn't allow extensions, so there's no need to worry about
+    // embedded name constraints in a v1 certificate.
+    match Cert::from_der(cert_der, EndEntityOrCa::EndEntity) {
+        Ok(cert) => Ok(TrustAnchor::from(cert)),
+        Err(Error::UnsupportedCertVersion) => {
+            extract_trust_anchor_from_v1_cert_der(cert_der).or(Err(Error::BadDer))
+        }
+        Err(err) => Err(err),
+    }
 }
 
-impl<'a> TrustAnchor<'a> {
-    /// Interprets the given DER-encoded certificate as a `TrustAnchor`. The
-    /// certificate is not validated. In particular, there is no check that the
-    /// certificate is self-signed or even that the certificate has the cA basic
-    /// constraint.
-    pub fn try_from_cert_der(cert_der: &'a [u8]) -> Result<Self, Error> {
-        let cert_der = untrusted::Input::from(cert_der);
+/// Parses a v1 certificate directly into a TrustAnchor.
+fn extract_trust_anchor_from_v1_cert_der(
+    cert_der: untrusted::Input<'_>,
+) -> Result<TrustAnchor<'_>, Error> {
+    // X.509 Certificate: https://tools.ietf.org/html/rfc5280#section-4.1.
+    cert_der.read_all(Error::BadDer, |cert_der| {
+        der::nested(
+            cert_der,
+            der::Tag::Sequence,
+            Error::TrailingData(DerTypeId::TrustAnchorV1),
+            |cert_der| {
+                let anchor = der::nested(
+                    cert_der,
+                    der::Tag::Sequence,
+                    Error::TrailingData(DerTypeId::TrustAnchorV1TbsCertificate),
+                    |tbs| {
+                        // The version number field does not appear in v1 certificates.
+                        lenient_certificate_serial_number(tbs)?;
 
-        // XXX: `EndEntityOrCA::EndEntity` is used instead of `EndEntityOrCA::CA`
-        // because we don't have a reference to a child cert, which is needed for
-        // `EndEntityOrCA::CA`. For this purpose, it doesn't matter.
-        //
-        // v1 certificates will result in `Error::BadDer` because `parse_cert` will
-        // expect a version field that isn't there. In that case, try to parse the
-        // certificate using a special parser for v1 certificates. Notably, that
-        // parser doesn't allow extensions, so there's no need to worry about
-        // embedded name constraints in a v1 certificate.
-        match Cert::from_der(cert_der, EndEntityOrCa::EndEntity) {
-            Ok(cert) => Ok(Self::from(cert)),
-            Err(Error::UnsupportedCertVersion) => {
-                Self::from_v1_der(cert_der).or(Err(Error::BadDer))
-            }
-            Err(err) => Err(err),
-        }
-    }
+                        skip(tbs, der::Tag::Sequence)?; // signature.
+                        skip(tbs, der::Tag::Sequence)?; // issuer.
+                        skip(tbs, der::Tag::Sequence)?; // validity.
+                        let subject = der::expect_tag(tbs, der::Tag::Sequence)?;
+                        let spki = der::expect_tag(tbs, der::Tag::Sequence)?;
 
-    /// Parses a v1 certificate directly into a TrustAnchor.
-    fn from_v1_der(cert_der: untrusted::Input<'a>) -> Result<Self, Error> {
-        // X.509 Certificate: https://tools.ietf.org/html/rfc5280#section-4.1.
-        cert_der.read_all(Error::BadDer, |cert_der| {
-            der::nested(
-                cert_der,
-                der::Tag::Sequence,
-                Error::TrailingData(DerTypeId::TrustAnchorV1),
-                |cert_der| {
-                    let anchor = der::nested(
-                        cert_der,
-                        der::Tag::Sequence,
-                        Error::TrailingData(DerTypeId::TrustAnchorV1TbsCertificate),
-                        |tbs| {
-                            // The version number field does not appear in v1 certificates.
-                            lenient_certificate_serial_number(tbs)?;
+                        Ok(TrustAnchor {
+                            subject: subject.as_slice_less_safe().into(),
+                            subject_public_key_info: spki.as_slice_less_safe().into(),
+                            name_constraints: None,
+                        })
+                    },
+                );
 
-                            skip(tbs, der::Tag::Sequence)?; // signature.
-                            skip(tbs, der::Tag::Sequence)?; // issuer.
-                            skip(tbs, der::Tag::Sequence)?; // validity.
-                            let subject = der::expect_tag(tbs, der::Tag::Sequence)?;
-                            let spki = der::expect_tag(tbs, der::Tag::Sequence)?;
+                // read and discard signatureAlgorithm + signature
+                skip(cert_der, der::Tag::Sequence)?;
+                skip(cert_der, der::Tag::BitString)?;
 
-                            Ok(TrustAnchor {
-                                subject: subject.as_slice_less_safe(),
-                                spki: spki.as_slice_less_safe(),
-                                name_constraints: None,
-                            })
-                        },
-                    );
-
-                    // read and discard signatureAlgorithm + signature
-                    skip(cert_der, der::Tag::Sequence)?;
-                    skip(cert_der, der::Tag::BitString)?;
-
-                    anchor
-                },
-            )
-        })
-    }
+                anchor
+            },
+        )
+    })
 }
 
 impl<'a> From<Cert<'a>> for TrustAnchor<'a> {
     fn from(cert: Cert<'a>) -> Self {
         Self {
-            subject: cert.subject.as_slice_less_safe(),
-            spki: cert.spki.as_slice_less_safe(),
-            name_constraints: cert.name_constraints.map(|nc| nc.as_slice_less_safe()),
+            subject: cert.subject.as_slice_less_safe().into(),
+            subject_public_key_info: cert.spki.as_slice_less_safe().into(),
+            name_constraints: cert
+                .name_constraints
+                .map(|nc| nc.as_slice_less_safe().into()),
         }
     }
 }

--- a/tests/cert_v1_unsupported.rs
+++ b/tests/cert_v1_unsupported.rs
@@ -12,14 +12,16 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use pki_types::CertificateDer;
+
 #[test]
 fn test_cert_v1_unsupported() {
     // Check with `openssl x509 -text -noout -in cert_v1.der -inform DER`
     // to verify this is a correct version 1 certificate.
-    const CERT_V1_DER: &[u8] = include_bytes!("cert_v1.der");
+    let ca = CertificateDer::from(&include_bytes!("cert_v1.der")[..]);
 
     assert_eq!(
         Some(webpki::Error::UnsupportedCertVersion),
-        webpki::EndEntityCert::try_from(CERT_V1_DER).err()
+        webpki::EndEntityCert::try_from(&ca).err()
     );
 }

--- a/tests/cert_without_extensions.rs
+++ b/tests/cert_without_extensions.rs
@@ -12,11 +12,12 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use pki_types::CertificateDer;
+
 #[test]
 fn cert_without_extensions_test() {
     // Check the certificate is valid with
     // `openssl x509 -in cert_without_extensions.der -inform DER -text -noout`
-    const CERT_WITHOUT_EXTENSIONS_DER: &[u8] = include_bytes!("cert_without_extensions.der");
-
-    assert!(webpki::EndEntityCert::try_from(CERT_WITHOUT_EXTENSIONS_DER).is_ok());
+    let ca = CertificateDer::from(&include_bytes!("cert_without_extensions.der")[..]);
+    assert!(webpki::EndEntityCert::try_from(&ca).is_ok());
 }

--- a/tests/client_auth.rs
+++ b/tests/client_auth.rs
@@ -13,7 +13,9 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #[cfg(feature = "alloc")]
-use webpki::KeyUsage;
+use pki_types::CertificateDer;
+#[cfg(feature = "alloc")]
+use webpki::{extract_trust_anchor, KeyUsage};
 
 #[cfg(feature = "alloc")]
 static ALL_SIGALGS: &[&dyn webpki::SignatureVerificationAlgorithm] = &[
@@ -30,10 +32,12 @@ static ALL_SIGALGS: &[&dyn webpki::SignatureVerificationAlgorithm] = &[
 
 #[cfg(feature = "alloc")]
 fn check_cert(ee: &[u8], ca: &[u8]) -> Result<(), webpki::Error> {
-    let anchors = &[webpki::TrustAnchor::try_from_cert_der(ca).unwrap()];
+    let ca = CertificateDer::from(ca);
+    let anchors = &[extract_trust_anchor(&ca).unwrap()];
 
     let time = webpki::Time::from_seconds_since_unix_epoch(0x1fed_f00d);
-    let cert = webpki::EndEntityCert::try_from(ee).unwrap();
+    let ee = CertificateDer::from(ee);
+    let cert = webpki::EndEntityCert::try_from(&ee).unwrap();
     cert.verify_for_usage(
         ALL_SIGALGS,
         anchors,

--- a/tests/signatures.rs
+++ b/tests/signatures.rs
@@ -14,7 +14,7 @@
 
 #![cfg(feature = "ring")]
 
-extern crate webpki;
+use pki_types::CertificateDer;
 
 #[cfg(feature = "alloc")]
 fn check_sig(
@@ -23,7 +23,8 @@ fn check_sig(
     message: &[u8],
     signature: &[u8],
 ) -> Result<(), webpki::Error> {
-    let cert = webpki::EndEntityCert::try_from(ee).unwrap();
+    let ee = CertificateDer::from(ee);
+    let cert = webpki::EndEntityCert::try_from(&ee).unwrap();
     cert.verify_signature(alg, message, signature)
 }
 

--- a/tests/tls_server_certs.rs
+++ b/tests/tls_server_certs.rs
@@ -13,7 +13,8 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #![cfg(feature = "alloc")]
 
-use webpki::KeyUsage;
+use pki_types::CertificateDer;
+use webpki::{extract_trust_anchor, KeyUsage};
 
 static ALL_SIGALGS: &[&dyn webpki::SignatureVerificationAlgorithm] = &[
     webpki::ECDSA_P256_SHA256,
@@ -33,10 +34,12 @@ fn check_cert(
     valid_names: &[&str],
     invalid_names: &[&str],
 ) -> Result<(), webpki::Error> {
-    let anchors = [webpki::TrustAnchor::try_from_cert_der(ca).unwrap()];
+    let ca_cert_der = CertificateDer::from(ca);
+    let anchors = [extract_trust_anchor(&ca_cert_der).unwrap()];
 
+    let ee_der = CertificateDer::from(ee);
     let time = webpki::Time::from_seconds_since_unix_epoch(0x1fed_f00d);
-    let cert = webpki::EndEntityCert::try_from(ee).unwrap();
+    let cert = webpki::EndEntityCert::try_from(&ee_der).unwrap();
     cert.verify_for_usage(
         ALL_SIGALGS,
         &anchors,


### PR DESCRIPTION
See https://github.com/rustls/pki-types/pull/1 for more context.

The `cargo package` and `cargo deny` failures in CI are expected given the temporary introduction of a git dependency. I'd expect we can release a pki-types 1.0.0-alpha.1 before we merge this, but want to get PRs to a bunch of other crates in place (and, ideally, reviewed) before we do that.