### PR TITLE
0.101.3 release prep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.101.2"
+version = "0.101.3"
 
 include = [
     "Cargo.toml",

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -143,7 +143,13 @@ impl<'a> EndEntityCert<'a> {
     /// `time` is the time for which the validation is effective (usually the
     /// current time).
     #[allow(deprecated)]
-    #[deprecated(since = "0.101.2", note = "Use `verify_for_usage` instead")]
+    #[deprecated(
+        since = "0.101.2",
+        note = "The per-usage trust anchor representations and verification functions are deprecated in \
+        favor of the general-purpose `TrustAnchor` type and `EndEntity::verify_for_usage` function. \
+        The new `verify_for_usage` function expresses trust anchor and end entity purpose with the \
+        key usage argument."
+    )]
     pub fn verify_is_valid_tls_server_cert(
         &self,
         supported_sig_algs: &[&SignatureAlgorithm],
@@ -173,7 +179,13 @@ impl<'a> EndEntityCert<'a> {
     /// the time for which the validation is effective (usually the current
     /// time).
     #[allow(deprecated)]
-    #[deprecated(since = "0.101.2", note = "Use `verify_for_usage` instead")]
+    #[deprecated(
+        since = "0.101.2",
+        note = "The per-usage trust anchor representations and verification functions are deprecated in \
+        favor of the general-purpose `TrustAnchor` type and `EndEntity::verify_for_usage` function. \
+        The new `verify_for_usage` function expresses trust anchor and end entity purpose with the \
+        key usage argument."
+    )]
     pub fn verify_is_valid_tls_client_cert(
         &self,
         supported_sig_algs: &[&SignatureAlgorithm],

--- a/src/trust_anchor.rs
+++ b/src/trust_anchor.rs
@@ -24,12 +24,24 @@ pub struct TrustAnchor<'a> {
 }
 
 /// Trust anchors which may be used for authenticating servers.
-#[deprecated(since = "0.101.2")]
+#[deprecated(
+    since = "0.101.2",
+    note = "The per-usage trust anchor representations and verification functions are deprecated in \
+        favor of the general-purpose `TrustAnchor` type and `EndEntity::verify_for_usage` function. \
+        The new `verify_for_usage` function expresses trust anchor and end entity purpose with the \
+        key usage argument."
+)]
 #[derive(Debug)]
 pub struct TlsServerTrustAnchors<'a>(pub &'a [TrustAnchor<'a>]);
 
 /// Trust anchors which may be used for authenticating clients.
-#[deprecated(since = "0.101.2")]
+#[deprecated(
+    since = "0.101.2",
+    note = "The per-usage trust anchor representations and verification functions are deprecated in \
+        favor of the general-purpose `TrustAnchor` type and `EndEntity::verify_for_usage` function. \
+        The new `verify_for_usage` function expresses trust anchor and end entity purpose with the \
+        key usage argument."
+)]
 #[derive(Debug)]
 pub struct TlsClientTrustAnchors<'a>(pub &'a [TrustAnchor<'a>]);
 


### PR DESCRIPTION
# 0.101.3 release prep

This branch (_that I should have named more generally, in retrospect_) targets a base of `rel-0.101`, created from the v0.101.2 tag.

The deprecations mentioned in https://github.com/rustls/webpki/issues/148 were in the released 0.101.2, but `main` has already removed the deprecated elements. In order to improve the deprecation notes we'll need to start a release branch. I've gone ahead and done that roughly following the [rustls guidance](https://github.com/rustls/rustls/blob/main/RELEASING.md#maintenance-point-releases).

### Proposed release notes

  - `TlsServerTrustAnchors`, `TlsClientTrustAnchors`, `verify_is_valid_tls_server_cert` and `verify_is_valid_tls_client_cert` deprecation notes improved.

### trust_anchor/end_entity: rework deprecation notes. 
In 0.101.2 we deprecated the `TlsServerTrustAnchors` and `TlsClientTrustAnchors` types along with the
`EndEntity::verify_is_valid_tls_server_cert` and
`EndEntity::verify_is_valid_tls_client_cert` functions that used them.

However, only the `EndEntity` deprecations had a `note` pointing to the preferred replacement, and the text was quite terse.

This commit adds notes to the trust anchor types that were missing these, and updates the end entity verification deprecation notes to be more user-friendly.

Thanks to @jsha for pointing out the omission in https://github.com/rustls/webpki/issues/148

### Cargo: version 0.101.2 -> 0.101.3 

Bumps the Cargo version for the release.

