### PR TITLE
verify_cert: enforce maximum number of signatures.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -93,6 +93,9 @@ pub enum Error {
     /// invalid labels.
     MalformedNameConstraint,
 
+    /// The maximum number of signature checks has been reached. Path complexity is too great.
+    MaximumSignatureChecksExceeded,
+
     /// The certificate violates one or more name constraints.
     NameConstraintViolation,
 
@@ -234,6 +237,9 @@ impl Error {
             // Generic DER errors.
             Error::BadDerTime => 2,
             Error::BadDer => 1,
+
+            // Special case error - not subject to ranking.
+            Error::MaximumSignatureChecksExceeded => 0,
 
             // Default catch all error - should be renamed in the future.
             Error::UnknownIssuer => 0,


### PR DESCRIPTION
Pathbuilding complexity can be quadratic, particularly when the set of intermediates all have subjects matching a trust anchor. In these cases we need to bound the number of expensive signature validation operations that are performed to avoid a DoS on CPU usage.

This commit implements a simple maximum signature check limit inspired by [the approach taken in the Golang x509 package](https://github.com/golang/go/commit/df523969435b8945d939c7e2a849b50910ef4c25). No more than 100 signatures will be evaluated while pathbuilding. This limit works in practice for Go when processing real world certificate chains and so should be appropriate for our use case as well.

Without the limit in place, the `test_too_many_signatures` unit test has very long runtime and quickly pegs my local CPU. With the limit in place the test returns the expected error quickly.