### PR TITLE
v0.100.2 prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,11 +92,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          # MSRV: Rust 1.47 and later have bugs in rustc that prevent some
-          # projects from upgrading past 1.46 yet. So, maintain compatibility
-          # for 1.46 until those bugs are fixed.
           # Make sure to update rust-version in Cargo.toml when updating MSRV.
-          toolchain: 1.46.0
+          toolchain: "1.60"
 
       - run: |
           cargo check --lib --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,24 @@ jobs:
 
       - run: cargo package
 
+  msrv:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          # MSRV: Rust 1.47 and later have bugs in rustc that prevent some
+          # projects from upgrading past 1.46 yet. So, maintain compatibility
+          # for 1.46 until those bugs are fixed.
+          # Make sure to update rust-version in Cargo.toml when updating MSRV.
+          toolchain: 1.46.0
+
+      - run: |
+          cargo check --lib --all-features
 
   test:
     runs-on: ${{ matrix.host_os }}
@@ -101,13 +119,6 @@ jobs:
         rust_channel:
           - stable
           - nightly
-
-          # MSRV: Rust 1.47 and later have bugs in rustc that prevent some
-          # projects from upgrading past 1.46 yet. So, maintain compatibility
-          # for 1.46 until those bugs are fixed.
-          # Make sure to update rust-version in Cargo.toml when updating MSRV.
-          - 1.46.0
-
           - beta
 
         exclude:
@@ -119,9 +130,6 @@ jobs:
           - features: --all-features
             mode: # debug
             rust_channel: nightly
-          - features: --all-features
-            mode: # debug
-            rust_channel: 1.46.0
           - features: --all-features
             mode: # debug
             rust_channel: beta
@@ -150,11 +158,6 @@ jobs:
           - features: --all-features
             mode: # debug
             rust_channel: nightly
-            host_os: ubuntu-20.04
-
-          - features: --all-features
-            mode: # debug
-            rust_channel: 1.46.0
             host_os: ubuntu-20.04
 
           - features: --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license-file = "LICENSE"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.100.1"
+version = "0.100.2"
 
 include = [
     "Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 categories = ["cryptography", "no-std"]
 description = "Web PKI X.509 Certificate Verification."
 edition = "2018"
-rust-version = "1.46"
+rust-version = "1.60"
 license-file = "LICENSE"
 name = "rustls-webpki"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ untrusted = "0.7.1"
 
 [dev-dependencies]
 base64 = "0.13"
+rcgen = { version = "0.11.1", default-features = false }
 
 [profile.bench]
 opt-level = 3

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -98,6 +98,7 @@ impl<'a> EndEntityCert<'a> {
             &self.inner,
             time,
             0,
+            &mut 0_usize,
         )
     }
 
@@ -130,6 +131,7 @@ impl<'a> EndEntityCert<'a> {
             &self.inner,
             time,
             0,
+            &mut 0_usize,
         )
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,6 +81,9 @@ pub enum Error {
     /// and as recommended by RFC6125.
     MalformedExtensions,
 
+    /// The maximum number of signature checks has been reached. Path complexity is too great.
+    MaximumSignatureChecksExceeded,
+
     /// The certificate contains an unsupported critical extension.
     UnsupportedCriticalExtension,
 


### PR DESCRIPTION
# 0.100.2 release prep

This branch targets a base of `rel-0.100` to prepare a point release in the v0.100.x series.

### Proposed release notes

  - certificate path building and verification is now capped at 100 signature validation operations to avoid the risk of CPU usage denial-of-service attack when validating crafted certificate chains producing quadratic runtime. This risk affected both clients, as well as servers that verified client certificates.
  
### verify_cert: enforce maximum number of signatures.
Pathbuilding complexity can be quadratic, particularly when the set of intermediates all have subjects matching a trust anchor. In these cases we need to bound the number of expensive signature validation operations that are performed to avoid a DoS on CPU usage.

This commit implements a simple maximum signature check limit inspired by the approach taken in the Golang x509 package. No more than 100 signatures will be evaluated while pathbuilding. This limit works in practice for Go when processing real world certificate chains and so should be appropriate for our use case as well.

### Cargo: version 0.100.1 -> 0.100.2

Bumps the Cargo version.