### PR TITLE
Enable warnings for `cargo doc` comments on private items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           toolchain: ${{ matrix.rust_channel }}
 
       - name: cargo doc (all features)
-        run: cargo doc --all-features
+        run: cargo doc --all-features --document-private-items
         env:
           RUSTDOCFLAGS: ${{ matrix.rust_channel == 'nightly' && '-Dwarnings --cfg=docsrs' || '-Dwarnings' }}
 

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -87,7 +87,7 @@ pub(crate) fn remember_extension(
 pub(crate) enum DistributionPointName<'a> {
     /// The distribution point name is a relative distinguished name, relative to the CRL issuer.
     NameRelativeToCrlIssuer(untrusted::Input<'a>),
-    /// The distribution point name is a sequence of [GeneralNames].
+    /// The distribution point name is a sequence of [GeneralName] items.
     FullName(DerIterator<'a, GeneralName<'a>>),
 }
 


### PR DESCRIPTION
Inspired by @ctz and https://github.com/rustls/rustls/pull/1419