### PR TITLE
subject_name: fix stale unused_imports allow.

### DIFF
--- a/src/subject_name/mod.rs
+++ b/src/subject_name/mod.rs
@@ -33,6 +33,4 @@ pub use ip_address::IpAddr;
 mod verify;
 #[cfg(feature = "alloc")]
 pub(super) use verify::list_cert_dns_names;
-#[allow(unused_imports)] // TODO(@cpu): remove once used by cert module.
-pub(crate) use verify::GeneralName;
-pub(super) use verify::{check_name_constraints, verify_cert_subject_name};
+pub(super) use verify::{check_name_constraints, verify_cert_subject_name, GeneralName};


### PR DESCRIPTION
Noticed this while backporting various changes for #170.

My kingdom for a `clippy` lint that can tell when `unused_imports` allows aren't needed anymore 😩