### PR TITLE
v0.100.3 preparation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license-file = "LICENSE"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.100.2"
+version = "0.100.3"
 
 include = [
     "Cargo.toml",

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -97,8 +97,6 @@ impl<'a> EndEntityCert<'a> {
             intermediate_certs,
             &self.inner,
             time,
-            0,
-            &mut 0_usize,
         )
     }
 
@@ -130,8 +128,6 @@ impl<'a> EndEntityCert<'a> {
             intermediate_certs,
             &self.inner,
             time,
-            0,
-            &mut 0_usize,
         )
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,6 +84,9 @@ pub enum Error {
     /// The maximum number of signature checks has been reached. Path complexity is too great.
     MaximumSignatureChecksExceeded,
 
+    /// The maximum number of internal path building calls has been reached. Path complexity is too great.
+    MaximumPathBuildCallsExceeded,
+
     /// The certificate contains an unsupported critical extension.
     UnsupportedCriticalExtension,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,8 +48,29 @@ pub enum Error {
     /// the notAfter time is earlier than the notBefore time.
     InvalidCertValidity,
 
+    /// A iPAddress name constraint was invalid:
+    /// - it had a sparse network mask (ie, cannot be written in CIDR form).
+    /// - it was too long or short
+    InvalidNetworkMaskConstraint,
+
     /// The signature is invalid for the given public key.
     InvalidSignatureForPublicKey,
+
+    /// The certificate extensions are malformed.
+    ///
+    /// In particular, webpki requires the DNS name(s) be in the subjectAltName
+    /// extension as required by the CA/Browser Forum Baseline Requirements
+    /// and as recommended by RFC6125.
+    MalformedExtensions,
+
+    /// The maximum number of internal path building calls has been reached. Path complexity is too great.
+    MaximumPathBuildCallsExceeded,
+
+    /// The path search was terminated because it became too deep.
+    MaximumPathDepthExceeded,
+
+    /// The maximum number of signature checks has been reached. Path complexity is too great.
+    MaximumSignatureChecksExceeded,
 
     /// The certificate violates one or more name constraints.
     NameConstraintViolation,
@@ -57,13 +78,13 @@ pub enum Error {
     /// The certificate violates one or more path length constraints.
     PathLenConstraintViolated,
 
-    /// The algorithm in the TBSCertificate "signature" field of a certificate
-    /// does not match the algorithm in the signature of the certificate.
-    SignatureAlgorithmMismatch,
-
     /// The certificate is not valid for the Extended Key Usage for which it is
     /// being validated.
     RequiredEkuNotFound,
+
+    /// The algorithm in the TBSCertificate "signature" field of a certificate
+    /// does not match the algorithm in the signature of the certificate.
+    SignatureAlgorithmMismatch,
 
     /// A valid issuer for the certificate could not be found.
     UnknownIssuer,
@@ -74,24 +95,12 @@ pub enum Error {
     /// is malformed.
     UnsupportedCertVersion,
 
-    /// The certificate extensions are malformed.
-    ///
-    /// In particular, webpki requires the DNS name(s) be in the subjectAltName
-    /// extension as required by the CA/Browser Forum Baseline Requirements
-    /// and as recommended by RFC6125.
-    MalformedExtensions,
-
-    /// The maximum number of signature checks has been reached. Path complexity is too great.
-    MaximumSignatureChecksExceeded,
-
-    /// The maximum number of internal path building calls has been reached. Path complexity is too great.
-    MaximumPathBuildCallsExceeded,
-
-    /// The path search was terminated because it became too deep.
-    MaximumPathDepthExceeded,
-
     /// The certificate contains an unsupported critical extension.
     UnsupportedCriticalExtension,
+
+    /// The signature algorithm for a signature is not in the set of supported
+    /// signature algorithms given.
+    UnsupportedSignatureAlgorithm,
 
     /// The signature's algorithm does not match the algorithm of the public
     /// key it is being validated for. This may be because the public key
@@ -101,15 +110,6 @@ pub enum Error {
     /// algorithm and the signature algorithm simply don't match (e.g.
     /// verifying an RSA signature with an ECC public key).
     UnsupportedSignatureAlgorithmForPublicKey,
-
-    /// The signature algorithm for a signature is not in the set of supported
-    /// signature algorithms given.
-    UnsupportedSignatureAlgorithm,
-
-    /// A iPAddress name constraint was invalid:
-    /// - it had a sparse network mask (ie, cannot be written in CIDR form).
-    /// - it was too long or short
-    InvalidNetworkMaskConstraint,
 }
 
 impl fmt::Display for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,9 @@ pub enum Error {
     /// and as recommended by RFC6125.
     MalformedExtensions,
 
+    /// The maximum number of name constraint comparisons has been reached.
+    MaximumNameConstraintComparisonsExceeded,
+
     /// The maximum number of internal path building calls has been reached. Path complexity is too great.
     MaximumPathBuildCallsExceeded,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,6 +87,9 @@ pub enum Error {
     /// The maximum number of internal path building calls has been reached. Path complexity is too great.
     MaximumPathBuildCallsExceeded,
 
+    /// The path search was terminated because it became too deep.
+    MaximumPathDepthExceeded,
+
     /// The certificate contains an unsupported critical extension.
     UnsupportedCriticalExtension,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -115,6 +115,20 @@ pub enum Error {
     UnsupportedSignatureAlgorithmForPublicKey,
 }
 
+impl Error {
+    /// Returns true for errors that should be considered fatal during path building. Errors of
+    /// this class should halt any further path building and be returned immediately.
+    #[inline]
+    pub(crate) fn is_fatal(&self) -> bool {
+        matches!(
+            self,
+            Error::MaximumSignatureChecksExceeded
+                | Error::MaximumPathBuildCallsExceeded
+                | Error::MaximumNameConstraintComparisonsExceeded
+        )
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -12,6 +12,7 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use crate::verify_cert::Budget;
 use crate::{der, Error};
 use ring::signature;
 
@@ -96,7 +97,10 @@ pub(crate) fn verify_signed_data(
     supported_algorithms: &[&SignatureAlgorithm],
     spki_value: untrusted::Input,
     signed_data: &SignedData,
+    budget: &mut Budget,
 ) -> Result<(), Error> {
+    budget.consume_signature()?;
+
     // We need to verify the signature in `signed_data` using the public key
     // in `public_key`. In order to know which *ring* signature verification
     // algorithm to use, we need to know the public key algorithm (ECDSA,
@@ -438,7 +442,8 @@ mod tests {
             signed_data::verify_signed_data(
                 SUPPORTED_ALGORITHMS_IN_TESTS,
                 spki_value,
-                &signed_data
+                &signed_data,
+                &mut Budget::default()
             )
         );
     }
@@ -735,6 +740,7 @@ mod tests {
         }
     }
 
+    use crate::verify_cert::Budget;
     use alloc::str::Lines;
 
     fn read_pem_section(lines: &mut Lines, section_name: &str) -> Vec<u8> {

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -84,11 +84,11 @@ pub(crate) fn verify_cert_subject_name(
 
 // https://tools.ietf.org/html/rfc5280#section-4.2.1.10
 pub(crate) fn check_name_constraints(
-    input: Option<&mut untrusted::Reader>,
+    constraints: Option<&mut untrusted::Reader>,
     subordinate_certs: &Cert,
     subject_common_name_contents: SubjectCommonNameContents,
 ) -> Result<(), Error> {
-    let input = match input {
+    let constraints = match constraints {
         Some(input) => input,
         None => {
             return Ok(());
@@ -105,8 +105,8 @@ pub(crate) fn check_name_constraints(
         der::expect_tag_and_get_value(inner, subtrees_tag).map(Some)
     }
 
-    let permitted_subtrees = parse_subtrees(input, der::Tag::ContextSpecificConstructed0)?;
-    let excluded_subtrees = parse_subtrees(input, der::Tag::ContextSpecificConstructed1)?;
+    let permitted_subtrees = parse_subtrees(constraints, der::Tag::ContextSpecificConstructed0)?;
+    let excluded_subtrees = parse_subtrees(constraints, der::Tag::ContextSpecificConstructed1)?;
 
     let mut child = subordinate_certs;
     loop {

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -104,7 +104,7 @@ fn build_chain_inner(
 
         let trust_anchor_spki = untrusted::Input::from(trust_anchor.spki);
 
-        check_signatures(supported_sig_algs, cert, trust_anchor_spki, budget)?;
+        check_signed_chain(supported_sig_algs, cert, trust_anchor_spki, budget)?;
 
         Ok(())
     });
@@ -166,7 +166,7 @@ fn build_chain_inner(
     })
 }
 
-fn check_signatures(
+fn check_signed_chain(
     supported_sig_algs: &[&SignatureAlgorithm],
     cert_chain: &Cert,
     trust_anchor_key: untrusted::Input,

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -505,7 +505,7 @@ mod tests {
             intermediates.pop();
         }
 
-        verify_chain(ca_cert_der, intermediates, make_end_entity(&issuer)).unwrap_err()
+        verify_chain(&ca_cert_der, &intermediates, &make_end_entity(&issuer)).unwrap_err()
     }
 
     #[test]
@@ -540,7 +540,7 @@ mod tests {
             issuer = intermediate;
         }
 
-        verify_chain(ca_cert_der, intermediates, make_end_entity(&issuer))
+        verify_chain(&ca_cert_der, &intermediates, &make_end_entity(&issuer))
     }
 
     #[test]
@@ -656,16 +656,16 @@ mod tests {
 
     #[cfg(feature = "alloc")]
     fn verify_chain(
-        trust_anchor_der: Vec<u8>,
-        intermediates_der: Vec<Vec<u8>>,
-        ee_cert_der: Vec<u8>,
+        trust_anchor_der: &[u8],
+        intermediates_der: &[Vec<u8>],
+        ee_cert_der: &[u8],
     ) -> Result<(), Error> {
         use crate::ECDSA_P256_SHA256;
         use crate::{EndEntityCert, Time};
 
-        let anchors = &[TrustAnchor::try_from_cert_der(&trust_anchor_der).unwrap()];
+        let anchors = &[TrustAnchor::try_from_cert_der(trust_anchor_der).unwrap()];
         let time = Time::from_seconds_since_unix_epoch(0x1fed_f00d);
-        let cert = EndEntityCert::try_from(&ee_cert_der[..]).unwrap();
+        let cert = EndEntityCert::try_from(ee_cert_der).unwrap();
         let intermediates_der = intermediates_der
             .iter()
             .map(|x| x.as_ref())

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -110,7 +110,8 @@ fn build_chain_inner(
     // If the error is not fatal, then keep going.
     match result {
         Ok(()) => return Ok(()),
-        err @ Err(Error::MaximumSignatureChecksExceeded) => return err,
+        err @ Err(Error::MaximumSignatureChecksExceeded)
+        | err @ Err(Error::MaximumPathBuildCallsExceeded) => return err,
         _ => {}
     };
 
@@ -149,6 +150,7 @@ fn build_chain_inner(
             UsedAsCa::Yes => sub_ca_count + 1,
         };
 
+        budget.consume_build_chain_call()?;
         build_chain_inner(
             required_eku_if_present,
             supported_sig_algs,
@@ -192,6 +194,7 @@ fn check_signatures(
 
 struct Budget {
     signatures: usize,
+    build_chain_calls: usize,
 }
 
 impl Budget {
@@ -201,6 +204,15 @@ impl Budget {
             .signatures
             .checked_sub(1)
             .ok_or(Error::MaximumSignatureChecksExceeded)?;
+        Ok(())
+    }
+
+    #[inline]
+    fn consume_build_chain_call(&mut self) -> Result<(), Error> {
+        self.build_chain_calls = self
+            .build_chain_calls
+            .checked_sub(1)
+            .ok_or(Error::MaximumPathBuildCallsExceeded)?;
         Ok(())
     }
 }
@@ -213,6 +225,10 @@ impl core::default::Default for Budget {
             // being hit in real applications (see <https://github.com/spiffe/spire/issues/1004>).
             // So this may actually be too aggressive.
             signatures: 100,
+
+            // This limit is taken from NSS libmozpkix, see:
+            // <https://github.com/nss-dev/nss/blob/bb4a1d38dd9e92923525ac6b5ed0288479f3f3fc/lib/mozpkix/lib/pkixbuild.cpp#L381-L393>
+            build_chain_calls: 200000,
         }
     }
 }
@@ -405,7 +421,8 @@ where
         // If the error is not fatal, then keep going.
         match f(v) {
             Ok(()) => return Ok(()),
-            err @ Err(Error::MaximumSignatureChecksExceeded) => return err,
+            err @ Err(Error::MaximumSignatureChecksExceeded)
+            | err @ Err(Error::MaximumPathBuildCallsExceeded) => return err,
             _ => {}
         }
     }
@@ -415,13 +432,21 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::convert::TryFrom;
 
-    #[test]
     #[cfg(feature = "alloc")]
-    fn test_too_many_signatures() {
-        use std::convert::TryFrom;
+    enum TrustAnchorIsActualIssuer {
+        Yes,
+        No,
+    }
 
-        use crate::{EndEntityCert, Time, ECDSA_P256_SHA256};
+    #[cfg(feature = "alloc")]
+    fn build_degenerate_chain(
+        intermediate_count: usize,
+        trust_anchor_is_actual_issuer: TrustAnchorIsActualIssuer,
+    ) -> Error {
+        use crate::ECDSA_P256_SHA256;
+        use crate::{EndEntityCert, Time};
 
         let alg = &rcgen::PKCS_ECDSA_P256_SHA256;
 
@@ -443,9 +468,9 @@ mod tests {
         let ca_cert = make_issuer();
         let ca_cert_der = ca_cert.serialize_der().unwrap();
 
-        let mut intermediates = Vec::with_capacity(101);
+        let mut intermediates = Vec::with_capacity(intermediate_count);
         let mut issuer = ca_cert;
-        for _ in 0..101 {
+        for _ in 0..intermediate_count {
             let intermediate = make_issuer();
             let intermediate_der = intermediate.serialize_der_with_signer(&issuer).unwrap();
             intermediates.push(intermediate_der);
@@ -461,18 +486,38 @@ mod tests {
         let anchors = &[TrustAnchor::try_from_cert_der(&ca_cert_der).unwrap()];
         let time = Time::from_seconds_since_unix_epoch(0x1fed_f00d);
         let cert = EndEntityCert::try_from(&ee_cert_der[..]).unwrap();
-        let intermediates_der: Vec<&[u8]> = intermediates.iter().map(|x| x.as_ref()).collect();
-        let intermediate_certs: &[&[u8]] = intermediates_der.as_ref();
+        let mut intermediate_certs = intermediates.iter().map(|x| x.as_ref()).collect::<Vec<_>>();
 
-        let result = build_chain(
+        if let TrustAnchorIsActualIssuer::No = trust_anchor_is_actual_issuer {
+            intermediate_certs.pop();
+        }
+
+        build_chain(
             EKU_SERVER_AUTH,
             &[&ECDSA_P256_SHA256],
             anchors,
-            intermediate_certs,
+            &intermediate_certs,
             cert.inner(),
             time,
-        );
+        )
+        .unwrap_err()
+    }
 
-        assert!(matches!(result, Err(Error::MaximumSignatureChecksExceeded)));
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn test_too_many_signatures() {
+        assert_eq!(
+            build_degenerate_chain(5, TrustAnchorIsActualIssuer::Yes),
+            Error::MaximumSignatureChecksExceeded
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn test_too_many_path_calls() {
+        assert_eq!(
+            build_degenerate_chain(10, TrustAnchorIsActualIssuer::No),
+            Error::MaximumPathBuildCallsExceeded
+        );
     }
 }

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -66,7 +66,7 @@ fn build_chain_inner(
             const MAX_SUB_CA_COUNT: usize = 6;
 
             if sub_ca_count >= MAX_SUB_CA_COUNT {
-                return Err(Error::UnknownIssuer);
+                return Err(Error::MaximumPathDepthExceeded);
             }
         }
         UsedAsCa::No => {
@@ -519,5 +519,80 @@ mod tests {
             build_degenerate_chain(10, TrustAnchorIsActualIssuer::No),
             Error::MaximumPathBuildCallsExceeded
         );
+    }
+
+    #[cfg(feature = "alloc")]
+    fn build_linear_chain(chain_length: usize) -> Result<(), Error> {
+        use crate::ECDSA_P256_SHA256;
+        use crate::{EndEntityCert, Time};
+
+        let alg = &rcgen::PKCS_ECDSA_P256_SHA256;
+
+        let make_issuer = |index: usize| {
+            let mut ca_params = rcgen::CertificateParams::new(Vec::new());
+            ca_params.distinguished_name.push(
+                rcgen::DnType::OrganizationName,
+                format!("Bogus Subject {index}"),
+            );
+            ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+            ca_params.key_usages = vec![
+                rcgen::KeyUsagePurpose::KeyCertSign,
+                rcgen::KeyUsagePurpose::DigitalSignature,
+                rcgen::KeyUsagePurpose::CrlSign,
+            ];
+            ca_params.alg = alg;
+            rcgen::Certificate::from_params(ca_params).unwrap()
+        };
+
+        let ca_cert = make_issuer(chain_length);
+        let ca_cert_der = ca_cert.serialize_der().unwrap();
+
+        let mut intermediates = Vec::with_capacity(chain_length);
+        let mut issuer = ca_cert;
+        for i in 0..chain_length {
+            let intermediate = make_issuer(i);
+            let intermediate_der = intermediate.serialize_der_with_signer(&issuer).unwrap();
+            intermediates.push(intermediate_der);
+            issuer = intermediate;
+        }
+
+        let mut ee_params = rcgen::CertificateParams::new(vec!["example.com".to_string()]);
+        ee_params.is_ca = rcgen::IsCa::ExplicitNoCa;
+        ee_params.alg = alg;
+        let ee_cert = rcgen::Certificate::from_params(ee_params).unwrap();
+        let ee_cert_der = ee_cert.serialize_der_with_signer(&issuer).unwrap();
+
+        let anchors = &[TrustAnchor::try_from_cert_der(&ca_cert_der).unwrap()];
+        let time = Time::from_seconds_since_unix_epoch(0x1fed_f00d);
+        let cert = EndEntityCert::try_from(&ee_cert_der[..]).unwrap();
+        let intermediates_der = intermediates.iter().map(|x| x.as_ref()).collect::<Vec<_>>();
+
+        build_chain(
+            EKU_SERVER_AUTH,
+            &[&ECDSA_P256_SHA256],
+            anchors,
+            &intermediates_der,
+            cert.inner(),
+            time,
+        )
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn longest_allowed_path() {
+        assert_eq!(build_linear_chain(1), Ok(()));
+        assert_eq!(build_linear_chain(2), Ok(()));
+        assert_eq!(build_linear_chain(3), Ok(()));
+        assert_eq!(build_linear_chain(4), Ok(()));
+        assert_eq!(build_linear_chain(5), Ok(()));
+        assert_eq!(build_linear_chain(6), Ok(()));
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn path_too_long() {
+        // Note: webpki 0.101.x and earlier surface all non-fatal errors as UnknownIssuer,
+        //       eating the more specific MaximumPathDepthExceeded error.
+        assert_eq!(build_linear_chain(7), Err(Error::UnknownIssuer));
     }
 }

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -229,7 +229,7 @@ impl Default for Budget {
 
             // This limit is taken from NSS libmozpkix, see:
             // <https://github.com/nss-dev/nss/blob/bb4a1d38dd9e92923525ac6b5ed0288479f3f3fc/lib/mozpkix/lib/pkixbuild.cpp#L381-L393>
-            build_chain_calls: 200000,
+            build_chain_calls: 200_000,
         }
     }
 }

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -12,6 +12,8 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use core::default::Default;
+
 use crate::{
     cert::{self, Cert, EndEntityOrCa},
     der, signed_data, subject_name, time, Error, SignatureAlgorithm, TrustAnchor,
@@ -217,7 +219,7 @@ impl Budget {
     }
 }
 
-impl core::default::Default for Budget {
+impl Default for Budget {
     fn default() -> Self {
         Self {
             // This limit is taken from the remediation for golang CVE-2018-16875.  However,

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -207,7 +207,13 @@ impl Budget {
 
 impl core::default::Default for Budget {
     fn default() -> Self {
-        Self { signatures: 100 }
+        Self {
+            // This limit is taken from the remediation for golang CVE-2018-16875.  However,
+            // note that golang subsequently implemented AKID matching due to this limit
+            // being hit in real applications (see <https://github.com/spiffe/spire/issues/1004>).
+            // So this may actually be too aggressive.
+            signatures: 100,
+        }
     }
 }
 

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -464,9 +464,9 @@ where
         // If the error is not fatal, then keep going.
         match f(v) {
             Ok(()) => return Ok(()),
-            err @ Err(Error::MaximumSignatureChecksExceeded)
-            | err @ Err(Error::MaximumPathBuildCallsExceeded)
-            | err @ Err(Error::MaximumNameConstraintComparisonsExceeded) => return err,
+            // Fatal errors should halt further looping.
+            res @ Err(err) if err.is_fatal() => return res,
+            // Non-fatal errors should allow looping to continue.
             _ => {}
         }
     }

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -175,8 +175,7 @@ fn check_signatures(
     let mut spki_value = trust_anchor_key;
     let mut cert = cert_chain;
     loop {
-        budget.consume_signature()?;
-        signed_data::verify_signed_data(supported_sig_algs, spki_value, &cert.signed_data)?;
+        signed_data::verify_signed_data(supported_sig_algs, spki_value, &cert.signed_data, budget)?;
 
         // TODO: check revocation
 
@@ -194,14 +193,14 @@ fn check_signatures(
     Ok(())
 }
 
-struct Budget {
+pub(crate) struct Budget {
     signatures: usize,
     build_chain_calls: usize,
 }
 
 impl Budget {
     #[inline]
-    fn consume_signature(&mut self) -> Result<(), Error> {
+    pub(crate) fn consume_signature(&mut self) -> Result<(), Error> {
         self.signatures = self
             .signatures
             .checked_sub(1)


### PR DESCRIPTION
## Description

This branch targets a base of rel-0.100 to prepare a point release in the v0.100.x series.

It brings in:
* https://github.com/rustls/webpki/pull/163
* https://github.com/rustls/webpki/pull/164
* https://github.com/rustls/webpki/pull/165
* https://github.com/rustls/webpki/pull/168

Unlike https://github.com/rustls/webpki/pull/170 we don't bring in clippy fixes (they applied to CRL code that isn't present in this branch), and we don't bring in the subject common name handling changes (since the problematic parsing isn't exposed to users via the name iteration code that's only in 0.101+ it didn't seem worthwhile).

I won't call out each individual commit this time since there are many :-) In terms of required adjustments for backporting there were more substantial changes in this branch than #170, largely due to the drift in APIs between releases. 

* Like with #170 all usages of `pki-types` abstractions had to be replaced with their legacy equivalents. 
* In general each commit that touched error types/handling needed to be adjusted for this branch where we don't have the `rank_error` notion. This is also reflected in 0b139abeb12e0ce25897ca7e5a2f4c3183ee50a9 having to adjust its expected error type in a unit test to the catch-all "UnknownIssuer" error.

## Proposed Release Notes

* Path building complexity is now limited to a maximum budget of path finding operations, avoiding exponential processing time when encountering certificate chains containing many certificates with the same subject/issuer distinguished name but different subject public key information. 
* Name constraints evaluation is now limited to a maximum number of comparison operations, avoiding exponential processing time when encountering certificate chains containing many name constraints and subject alternate names.
