### PR TITLE
tests: local test speed optimizations, add cargo hack feature powerset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
           toolchain: ${{ matrix.rust_channel }}
 
       - name: cargo test (${{ matrix.mode }}, ${{ matrix.features }})
-        run: cargo test -vv ${{ matrix.features }} ${{ matrix.mode }}
+        run: cargo test -vv ${{ matrix.features }} ${{ matrix.mode }} -- --ignored
         env:
           RUSTFLAGS: "-D warnings"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,3 +292,21 @@ jobs:
 
       - name: check no-std mode
         run: cargo check --target $NOSTD_TARGET ${{ matrix.features  }}
+
+  feature-powerset:
+    name: Feature Powerset
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: Check feature powerset
+        run: cargo hack check --feature-powerset --no-dev-deps

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -555,7 +555,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "alloc")]
-    fn test_too_many_path_calls() {
+    fn test_too_many_path_calls_mini() {
         assert!(matches!(
             build_degenerate_chain(
                 10,
@@ -565,6 +565,10 @@ mod tests {
                     // first expending the signature checks budget is tricky, so we artificially
                     // inflate the signature limit to make this test easier to write.
                     signatures: usize::MAX,
+                    // We don't use the default build chain budget here. Doing so makes this test
+                    // run slowly (due to testing quadratic runtime up to the limit) without adding
+                    // much value from a testing perspective over using a smaller non-default limit.
+                    build_chain_calls: 100,
                     ..Budget::default()
                 })
             ),

--- a/tests/better_tls.rs
+++ b/tests/better_tls.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 use webpki::types::{CertificateDer, TrustAnchor};
 use webpki::{extract_trust_anchor, KeyUsage, SubjectNameRef};
 
+#[ignore] // Runs slower than other unit tests - opt-in with `cargo test -- --ignored`
 #[test]
 fn better_tls() {
     let better_tls = testdata();
@@ -30,6 +31,7 @@ fn better_tls() {
     );
 }
 
+#[ignore] // Runs slower than other unit tests - opt-in with `cargo test -- --ignored`
 #[test]
 fn name_constraints() {
     let better_tls = testdata();

--- a/tests/better_tls.rs
+++ b/tests/better_tls.rs
@@ -14,7 +14,7 @@ use webpki::{extract_trust_anchor, KeyUsage, SubjectNameRef};
 
 #[ignore] // Runs slower than other unit tests - opt-in with `cargo test -- --ignored`
 #[test]
-fn better_tls() {
+fn path_building() {
     let better_tls = testdata();
     let root_der = &better_tls.root_der();
     let root_der = CertificateDer::from(root_der.as_slice());


### PR DESCRIPTION
Recently our unit test runtime has been bogging down. Three tests in particular were slow relative to the rest: `test_too_many_path_calls` from `verify_cert.rs`, and the path building and name constraint test suites from the [bettertls](https://github.com/Netflix/bettertls) based integration test. Our entire project test suite minus those three tests completes in <0.5s.  Running `test_too_many_path_calls` alone takes ~3s, and the better tls suite was ~8s.

This branch does a few things to remedy this:

* It makes `test_too_many_path_calls` run faster by setting a lower `build_chain_calls` budget.
* It makes the better tls test suite opt-in by ignoring both tests by default.
* It updates CI to run ignored tests.
* It adds a `cargo hack` feature powerset test to CI.

This should help keep regular development fast while still maintaining good coverage.