### PR TITLE
docs: add CONTRIBUTING.md, ref'ing Rustls CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Thanks for considering helping this project. There are many ways you can help:
+using the library and reporting bugs, reporting usability issues, making
+additions and improvements to the library, documentation and finding security
+bugs.
+
+Please see the [Rustls CONTRIBUTING.md](https://github.com/rustls/rustls/blob/main/CONTRIBUTING.md)
+for more information on reporting bugs, making code changes, and our style
+guide.


### PR DESCRIPTION
Rather than maintain the same content in two places let's just point webpki contributors to the Rustls `CONTRIBUTING.md`.