### PR TITLE
rework `dns_names` helper, remove alloc req.

### DIFF
--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -212,7 +212,7 @@ mod tests {
             EndEntityCert::try_from(der).expect("should parse end entity certificate correctly");
 
         let mut names = cert.dns_names();
-        assert_eq!(names.next().map(<&str>::from), Some(name));
-        assert_eq!(names.next().map(<&str>::from), None);
+        assert_eq!(names.next(), Some(name));
+        assert_eq!(names.next(), None);
     }
 }

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -16,8 +16,6 @@ use pki_types::{CertificateDer, SignatureVerificationAlgorithm, TrustAnchor, Uni
 
 use crate::crl::RevocationOptions;
 use crate::error::Error;
-#[cfg(feature = "alloc")]
-use crate::subject_name::GeneralDnsNameRef;
 use crate::subject_name::{self, SubjectNameRef};
 use crate::verify_cert::{self, KeyUsage};
 use crate::{cert, signed_data};
@@ -156,7 +154,7 @@ impl<'a> EndEntityCert<'a> {
     /// Verification functions are already provided as `verify_is_valid_for_dns_name`
     /// and `verify_is_valid_for_at_least_one_dns_name`.
     #[cfg(feature = "alloc")]
-    pub fn dns_names(&'a self) -> Result<impl Iterator<Item = GeneralDnsNameRef<'a>>, Error> {
+    pub fn dns_names(&'a self) -> Result<impl Iterator<Item = &'a str>, Error> {
         subject_name::list_cert_dns_names(self)
     }
 }

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -154,7 +154,7 @@ impl<'a> EndEntityCert<'a> {
     /// Checking that a certificate is valid for a given subject name should always be done with
     /// [EndEntityCert::verify_is_valid_for_subject_name].
     pub fn dns_names(&'a self) -> impl Iterator<Item = &'a str> {
-        subject_name::list_cert_dns_names(self)
+        self.inner.valid_dns_names()
     }
 }
 

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -148,13 +148,13 @@ impl<'a> EndEntityCert<'a> {
         )
     }
 
-    /// Returns a list of the DNS names provided in the subject alternative names extension
+    /// Returns a list of valid DNS names provided in the subject alternative names extension
     ///
     /// This function must not be used to implement custom DNS name verification.
     /// Checking that a certificate is valid for a given subject name should always be done with
     /// [EndEntityCert::verify_is_valid_for_subject_name].
     #[cfg(feature = "alloc")]
-    pub fn dns_names(&'a self) -> Result<impl Iterator<Item = &'a str>, Error> {
+    pub fn dns_names(&'a self) -> impl Iterator<Item = &'a str> {
         subject_name::list_cert_dns_names(self)
     }
 }
@@ -212,9 +212,7 @@ mod tests {
         let cert =
             EndEntityCert::try_from(der).expect("should parse end entity certificate correctly");
 
-        let mut names = cert
-            .dns_names()
-            .expect("should get all DNS names correctly for end entity cert");
+        let mut names = cert.dns_names();
         assert_eq!(names.next().map(<&str>::from), Some(name));
         assert_eq!(names.next().map(<&str>::from), None);
     }

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -153,7 +153,6 @@ impl<'a> EndEntityCert<'a> {
     /// This function must not be used to implement custom DNS name verification.
     /// Checking that a certificate is valid for a given subject name should always be done with
     /// [EndEntityCert::verify_is_valid_for_subject_name].
-    #[cfg(feature = "alloc")]
     pub fn dns_names(&'a self) -> impl Iterator<Item = &'a str> {
         subject_name::list_cert_dns_names(self)
     }

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -151,8 +151,8 @@ impl<'a> EndEntityCert<'a> {
     /// Returns a list of the DNS names provided in the subject alternative names extension
     ///
     /// This function must not be used to implement custom DNS name verification.
-    /// Verification functions are already provided as `verify_is_valid_for_dns_name`
-    /// and `verify_is_valid_for_at_least_one_dns_name`.
+    /// Checking that a certificate is valid for a given subject name should always be done with
+    /// [EndEntityCert::verify_is_valid_for_subject_name].
     #[cfg(feature = "alloc")]
     pub fn dns_names(&'a self) -> Result<impl Iterator<Item = &'a str>, Error> {
         subject_name::list_cert_dns_names(self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,6 @@ pub use {
 
 pub use pki_types as types;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg(feature = "alloc")]
 pub use {
     crl::{OwnedCertRevocationList, OwnedRevokedCert},

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -92,6 +92,7 @@ impl<'a> SignedData<'a> {
     ///     signatureAlgorithm AlgorithmIdentifier,
     ///     signatureValue BIT STRING
     /// }
+    /// ```
     ///
     /// OCSP responses (RFC 6960) look like this:
     /// ```ASN.1

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -32,7 +32,7 @@ impl<'a> From<GeneralDnsNameRef<'a>> for &'a str {
     fn from(d: GeneralDnsNameRef<'a>) -> Self {
         match d {
             GeneralDnsNameRef::DnsName(name) => name.as_str(),
-            GeneralDnsNameRef::Wildcard(name) => name.into(),
+            GeneralDnsNameRef::Wildcard(name) => name.as_str(),
         }
     }
 }
@@ -168,6 +168,13 @@ impl<'a> WildcardDnsNameRef<'a> {
     pub fn try_from_ascii_str(dns_name: &'a str) -> Result<Self, InvalidDnsNameError> {
         Self::try_from_ascii(dns_name.as_bytes())
     }
+
+    /// Yields a reference to the DNS name as a `&str`.
+    pub fn as_str(&self) -> &'a str {
+        // The unwrap won't fail because a `WildcardDnsNameRef` is guaranteed to be ASCII and
+        // ASCII is a subset of UTF-8.
+        core::str::from_utf8(self.0).unwrap()
+    }
 }
 
 impl core::fmt::Debug for WildcardDnsNameRef<'_> {
@@ -182,23 +189,6 @@ impl core::fmt::Debug for WildcardDnsNameRef<'_> {
         }
 
         f.write_str("\")")
-    }
-}
-
-impl<'a> From<WildcardDnsNameRef<'a>> for &'a str {
-    fn from(WildcardDnsNameRef(d): WildcardDnsNameRef<'a>) -> Self {
-        // The unwrap won't fail because WildcardDnsNameRef are guaranteed to be ASCII
-        // and ASCII is a subset of UTF-8.
-        core::str::from_utf8(d).unwrap()
-    }
-}
-
-impl AsRef<str> for WildcardDnsNameRef<'_> {
-    #[inline]
-    fn as_ref(&self) -> &str {
-        // The unwrap won't fail because WildcardDnsNameRef are guaranteed to be ASCII
-        // and ASCII is a subset of UTF-8.
-        core::str::from_utf8(self.0).unwrap()
     }
 }
 

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -72,20 +72,6 @@ impl AsRef<str> for DnsNameRef<'_> {
     }
 }
 
-/// An error indicating that a `DnsNameRef` could not built because the input
-/// is not a syntactically-valid DNS Name.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct InvalidDnsNameError;
-
-impl core::fmt::Display for InvalidDnsNameError {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-#[cfg(feature = "std")]
-impl ::std::error::Error for InvalidDnsNameError {}
-
 impl<'a> DnsNameRef<'a> {
     /// Constructs a `DnsNameRef` from the given input if the input is a
     /// syntactically-valid DNS name.
@@ -227,6 +213,20 @@ impl AsRef<str> for WildcardDnsNameRef<'_> {
         core::str::from_utf8(self.0).unwrap()
     }
 }
+
+/// An error indicating that a `DnsNameRef` could not built because the input
+/// is not a syntactically-valid DNS Name.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct InvalidDnsNameError;
+
+impl core::fmt::Display for InvalidDnsNameError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl ::std::error::Error for InvalidDnsNameError {}
 
 pub(super) fn presented_id_matches_reference_id(
     presented_dns_id: untrusted::Input,

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -28,11 +28,12 @@ pub enum GeneralDnsNameRef<'name> {
     Wildcard(WildcardDnsNameRef<'name>),
 }
 
-impl<'a> From<GeneralDnsNameRef<'a>> for &'a str {
-    fn from(d: GeneralDnsNameRef<'a>) -> Self {
-        match d {
-            GeneralDnsNameRef::DnsName(name) => name.as_str(),
-            GeneralDnsNameRef::Wildcard(name) => name.as_str(),
+impl<'a> GeneralDnsNameRef<'a> {
+    /// Yields the DNS name as a `&str`.
+    pub fn as_str(&self) -> &'a str {
+        match self {
+            Self::DnsName(name) => name.as_str(),
+            Self::Wildcard(name) => name.as_str(),
         }
     }
 }

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -18,6 +18,25 @@ use core::fmt::Write;
 
 use crate::Error;
 
+/// A DNS name that may be either a DNS name identifier presented by a server (which may include
+/// wildcards), or a DNS name identifier referenced by a client for matching purposes (wildcards
+/// not permitted).
+pub enum GeneralDnsNameRef<'name> {
+    /// a reference to a DNS name that may be used for matching purposes.
+    DnsName(DnsNameRef<'name>),
+    /// a reference to a presented DNS name that may include a wildcard.
+    Wildcard(WildcardDnsNameRef<'name>),
+}
+
+impl<'a> From<GeneralDnsNameRef<'a>> for &'a str {
+    fn from(d: GeneralDnsNameRef<'a>) -> Self {
+        match d {
+            GeneralDnsNameRef::DnsName(name) => name.into(),
+            GeneralDnsNameRef::Wildcard(name) => name.into(),
+        }
+    }
+}
+
 /// A DNS Name suitable for use in the TLS Server Name Indication (SNI)
 /// extension and/or for use as the reference hostname for which to verify a
 /// certificate.
@@ -123,25 +142,6 @@ impl<'a> From<DnsNameRef<'a>> for &'a str {
         // The unwrap won't fail because DnsNameRefs are guaranteed to be ASCII
         // and ASCII is a subset of UTF-8.
         core::str::from_utf8(d).unwrap()
-    }
-}
-
-/// A DNS name that may be either a DNS name identifier presented by a server (which may include
-/// wildcards), or a DNS name identifier referenced by a client for matching purposes (wildcards
-/// not permitted).
-pub enum GeneralDnsNameRef<'name> {
-    /// a reference to a DNS name that may be used for matching purposes.
-    DnsName(DnsNameRef<'name>),
-    /// a reference to a presented DNS name that may include a wildcard.
-    Wildcard(WildcardDnsNameRef<'name>),
-}
-
-impl<'a> From<GeneralDnsNameRef<'a>> for &'a str {
-    fn from(d: GeneralDnsNameRef<'a>) -> Self {
-        match d {
-            GeneralDnsNameRef::DnsName(name) => name.into(),
-            GeneralDnsNameRef::Wildcard(name) => name.into(),
-        }
     }
 }
 

--- a/src/subject_name/mod.rs
+++ b/src/subject_name/mod.rs
@@ -13,8 +13,6 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 mod dns_name;
-#[cfg(feature = "alloc")]
-pub(crate) use dns_name::GeneralDnsNameRef;
 pub use dns_name::{DnsNameRef, InvalidDnsNameError};
 
 #[cfg(feature = "alloc")]

--- a/src/subject_name/mod.rs
+++ b/src/subject_name/mod.rs
@@ -28,6 +28,6 @@ pub use ip_address::{AddrParseError, IpAddrRef};
 pub use ip_address::IpAddr;
 
 mod verify;
-#[cfg(feature = "alloc")]
-pub(super) use verify::list_cert_dns_names;
-pub(super) use verify::{check_name_constraints, verify_cert_subject_name, GeneralName};
+pub(super) use verify::{
+    check_name_constraints, list_cert_dns_names, verify_cert_subject_name, GeneralName,
+};

--- a/src/subject_name/mod.rs
+++ b/src/subject_name/mod.rs
@@ -17,7 +17,6 @@ mod dns_name;
 pub(crate) use dns_name::GeneralDnsNameRef;
 pub use dns_name::{DnsNameRef, InvalidDnsNameError};
 
-/// Requires the `alloc` feature.
 #[cfg(feature = "alloc")]
 pub use dns_name::DnsName;
 

--- a/src/subject_name/mod.rs
+++ b/src/subject_name/mod.rs
@@ -13,6 +13,7 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 mod dns_name;
+pub(super) use dns_name::WildcardDnsNameRef;
 pub use dns_name::{DnsNameRef, InvalidDnsNameError};
 
 #[cfg(feature = "alloc")]
@@ -29,5 +30,5 @@ pub use ip_address::IpAddr;
 
 mod verify;
 pub(super) use verify::{
-    check_name_constraints, list_cert_dns_names, verify_cert_subject_name, GeneralName,
+    check_name_constraints, verify_cert_subject_name, GeneralName, NameIterator,
 };

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -320,7 +320,7 @@ impl<'a> Iterator for NameIterator<'a> {
 #[cfg(feature = "alloc")]
 pub(crate) fn list_cert_dns_names<'names>(
     cert: &'names crate::EndEntityCert<'names>,
-) -> Result<impl Iterator<Item = GeneralDnsNameRef<'names>>, Error> {
+) -> Result<impl Iterator<Item = &'names str>, Error> {
     let cert = &cert.inner();
     let mut names = Vec::new();
 
@@ -346,7 +346,7 @@ pub(crate) fn list_cert_dns_names<'names>(
             // if the name could be converted to a DNS name, add it; otherwise,
             // keep going.
             if let Ok(name) = dns_name {
-                names.push(name)
+                names.push(name.into())
             }
 
             None

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -325,9 +325,9 @@ pub(crate) fn list_cert_dns_names<'names>(
         // if the name could be converted to a DNS name, return it; otherwise,
         // keep going.
         match DnsNameRef::try_from_ascii(presented_id.as_slice_less_safe()) {
-            Ok(dns_name) => Some(dns_name.into()),
+            Ok(dns_name) => Some(dns_name.as_str()),
             Err(_) => match WildcardDnsNameRef::try_from_ascii(presented_id.as_slice_less_safe()) {
-                Ok(wildcard_dns_name) => Some(wildcard_dns_name.into()),
+                Ok(wildcard_dns_name) => Some(wildcard_dns_name.as_str()),
                 Err(_) => None,
             },
         }

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -24,7 +24,7 @@ pub(crate) fn verify_cert_dns_name(
     dns_name: DnsNameRef,
 ) -> Result<(), Error> {
     let cert = cert.inner();
-    let dns_name = untrusted::Input::from(dns_name.as_ref().as_bytes());
+    let dns_name = untrusted::Input::from(dns_name.as_str().as_bytes());
     NameIterator::new(Some(cert.subject), cert.subject_alt_name)
         .find_map(|result| {
             let name = match result {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -332,10 +332,10 @@ fn wildcard_subject_alternative_names() {
 }
 
 #[cfg(feature = "alloc")]
-fn expect_cert_dns_names(data: &[u8], expected_names: &[&str]) {
+fn expect_cert_dns_names(cert_der: &[u8], expected_names: &[&str]) {
     use std::collections::HashSet;
 
-    let der = CertificateDer::from(data);
+    let der = CertificateDer::from(cert_der);
     let cert = webpki::EndEntityCert::try_from(&der)
         .expect("should parse end entity certificate correctly");
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -255,7 +255,6 @@ fn read_ee_with_large_pos_serial() {
     webpki::EndEntityCert::try_from(&ee).expect("should parse 20-octet positive serial number");
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn list_netflix_names() {
     expect_cert_dns_names(
@@ -277,7 +276,6 @@ fn list_netflix_names() {
     );
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn invalid_subject_alt_names() {
     expect_cert_dns_names(
@@ -301,7 +299,6 @@ fn invalid_subject_alt_names() {
     );
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn wildcard_subject_alternative_names() {
     expect_cert_dns_names(
@@ -325,13 +322,11 @@ fn wildcard_subject_alternative_names() {
     );
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn no_subject_alt_names() {
     expect_cert_dns_names(include_bytes!("misc/no_subject_alternative_name.der"), [])
 }
 
-#[cfg(feature = "alloc")]
 fn expect_cert_dns_names<'name>(
     cert_der: &[u8],
     expected_names: impl IntoIterator<Item = &'name str>,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -258,10 +258,8 @@ fn read_ee_with_large_pos_serial() {
 #[cfg(feature = "alloc")]
 #[test]
 fn list_netflix_names() {
-    let ee = include_bytes!("netflix/ee.der");
-
     expect_cert_dns_names(
-        ee,
+        include_bytes!("netflix/ee.der"),
         [
             "account.netflix.com",
             "ca.netflix.com",
@@ -282,12 +280,10 @@ fn list_netflix_names() {
 #[cfg(feature = "alloc")]
 #[test]
 fn invalid_subject_alt_names() {
-    // same as netflix ee certificate, but with the last name in the list
-    // changed to 'www.netflix:com'
-    let data = include_bytes!("misc/invalid_subject_alternative_name.der");
-
     expect_cert_dns_names(
-        data,
+        // same as netflix ee certificate, but with the last name in the list
+        // changed to 'www.netflix:com'
+        include_bytes!("misc/invalid_subject_alternative_name.der"),
         [
             "account.netflix.com",
             "ca.netflix.com",
@@ -308,12 +304,10 @@ fn invalid_subject_alt_names() {
 #[cfg(feature = "alloc")]
 #[test]
 fn wildcard_subject_alternative_names() {
-    // same as netflix ee certificate, but with the last name in the list
-    // changed to 'ww*.netflix:com'
-    let data = include_bytes!("misc/dns_names_and_wildcards.der");
-
     expect_cert_dns_names(
-        data,
+        // same as netflix ee certificate, but with the last name in the list
+        // changed to 'ww*.netflix:com'
+        include_bytes!("misc/dns_names_and_wildcards.der"),
         [
             "account.netflix.com",
             "*.netflix.com",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -262,7 +262,7 @@ fn list_netflix_names() {
 
     expect_cert_dns_names(
         ee,
-        &[
+        [
             "account.netflix.com",
             "ca.netflix.com",
             "netflix.ca",
@@ -288,7 +288,7 @@ fn invalid_subject_alt_names() {
 
     expect_cert_dns_names(
         data,
-        &[
+        [
             "account.netflix.com",
             "ca.netflix.com",
             "netflix.ca",
@@ -314,7 +314,7 @@ fn wildcard_subject_alternative_names() {
 
     expect_cert_dns_names(
         data,
-        &[
+        [
             "account.netflix.com",
             "*.netflix.com",
             "netflix.ca",
@@ -332,28 +332,15 @@ fn wildcard_subject_alternative_names() {
 }
 
 #[cfg(feature = "alloc")]
-fn expect_cert_dns_names(cert_der: &[u8], expected_names: &[&str]) {
-    use std::collections::HashSet;
-
+fn expect_cert_dns_names<'name>(
+    cert_der: &[u8],
+    expected_names: impl IntoIterator<Item = &'name str>,
+) {
     let der = CertificateDer::from(cert_der);
     let cert = webpki::EndEntityCert::try_from(&der)
         .expect("should parse end entity certificate correctly");
 
-    let expected_names: HashSet<_> = expected_names.iter().cloned().collect();
-
-    let mut actual_names = cert
-        .dns_names()
-        .expect("should get all DNS names correctly for end entity cert")
-        .collect::<Vec<_>>();
-
-    // Ensure that converting the list to a set doesn't throw away
-    // any duplicates that aren't supposed to be there
-    assert_eq!(actual_names.len(), expected_names.len());
-
-    let actual_names: std::collections::HashSet<&str> =
-        actual_names.drain(..).map(|name| name.into()).collect();
-
-    assert_eq!(actual_names, expected_names);
+    assert!(cert.dns_names().unwrap().eq(expected_names))
 }
 
 #[cfg(feature = "alloc")]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -332,18 +332,6 @@ fn wildcard_subject_alternative_names() {
 }
 
 #[cfg(feature = "alloc")]
-fn expect_cert_dns_names<'name>(
-    cert_der: &[u8],
-    expected_names: impl IntoIterator<Item = &'name str>,
-) {
-    let der = CertificateDer::from(cert_der);
-    let cert = webpki::EndEntityCert::try_from(&der)
-        .expect("should parse end entity certificate correctly");
-
-    assert!(cert.dns_names().unwrap().eq(expected_names))
-}
-
-#[cfg(feature = "alloc")]
 #[test]
 fn no_subject_alt_names() {
     let ee = CertificateDer::from(&include_bytes!("misc/no_subject_alternative_name.der")[..]);
@@ -356,4 +344,16 @@ fn no_subject_alt_names() {
         .expect("we should get a result even without subjectAltNames");
 
     assert!(names.collect::<Vec<_>>().is_empty());
+}
+
+#[cfg(feature = "alloc")]
+fn expect_cert_dns_names<'name>(
+    cert_der: &[u8],
+    expected_names: impl IntoIterator<Item = &'name str>,
+) {
+    let der = CertificateDer::from(cert_der);
+    let cert = webpki::EndEntityCert::try_from(&der)
+        .expect("should parse end entity certificate correctly");
+
+    assert!(cert.dns_names().unwrap().eq(expected_names))
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -334,16 +334,7 @@ fn wildcard_subject_alternative_names() {
 #[cfg(feature = "alloc")]
 #[test]
 fn no_subject_alt_names() {
-    let ee = CertificateDer::from(&include_bytes!("misc/no_subject_alternative_name.der")[..]);
-
-    let cert = webpki::EndEntityCert::try_from(&ee)
-        .expect("should parse end entity certificate correctly");
-
-    let names = cert
-        .dns_names()
-        .expect("we should get a result even without subjectAltNames");
-
-    assert!(names.collect::<Vec<_>>().is_empty());
+    expect_cert_dns_names(include_bytes!("misc/no_subject_alternative_name.der"), [])
 }
 
 #[cfg(feature = "alloc")]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -340,5 +340,5 @@ fn expect_cert_dns_names<'name>(
     let cert = webpki::EndEntityCert::try_from(&der)
         .expect("should parse end entity certificate correctly");
 
-    assert!(cert.dns_names().unwrap().eq(expected_names))
+    assert!(cert.dns_names().eq(expected_names))
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -39,7 +39,7 @@ static ALL_SIGALGS: &[&dyn SignatureVerificationAlgorithm] = &[
  * because they're rooted at a Verisign v1 root. */
 #[cfg(feature = "alloc")]
 #[test]
-pub fn netflix() {
+fn netflix() {
     let ee: &[u8] = include_bytes!("netflix/ee.der");
     let inter = CertificateDer::from(&include_bytes!("netflix/inter.der")[..]);
     let ca = CertificateDer::from(&include_bytes!("netflix/ca.der")[..]);
@@ -66,7 +66,7 @@ pub fn netflix() {
 /* This is notable because it is a popular use of IP address subjectAltNames. */
 #[cfg(feature = "alloc")]
 #[test]
-pub fn cloudflare_dns() {
+fn cloudflare_dns() {
     let ee: &[u8] = include_bytes!("cloudflare_dns/ee.der");
     let inter = CertificateDer::from(&include_bytes!("cloudflare_dns/inter.der")[..]);
     let ca = CertificateDer::from(&include_bytes!("cloudflare_dns/ca.der")[..]);
@@ -123,7 +123,7 @@ pub fn cloudflare_dns() {
 
 #[cfg(feature = "alloc")]
 #[test]
-pub fn wpt() {
+fn wpt() {
     let ee = CertificateDer::from(&include_bytes!("wpt/ee.der")[..]);
     let ca = CertificateDer::from(&include_bytes!("wpt/ca.der")[..]);
 
@@ -145,7 +145,7 @@ pub fn wpt() {
 }
 
 #[test]
-pub fn ed25519() {
+fn ed25519() {
     let ee = CertificateDer::from(&include_bytes!("ed25519/ee.der")[..]);
     let ca = CertificateDer::from(&include_bytes!("ed25519/ca.der")[..]);
 
@@ -257,7 +257,7 @@ fn read_ee_with_large_pos_serial() {
 
 #[cfg(feature = "alloc")]
 #[test]
-pub fn list_netflix_names() {
+fn list_netflix_names() {
     let ee = include_bytes!("netflix/ee.der");
 
     expect_cert_dns_names(
@@ -281,7 +281,7 @@ pub fn list_netflix_names() {
 
 #[cfg(feature = "alloc")]
 #[test]
-pub fn invalid_subject_alt_names() {
+fn invalid_subject_alt_names() {
     // same as netflix ee certificate, but with the last name in the list
     // changed to 'www.netflix:com'
     let data = include_bytes!("misc/invalid_subject_alternative_name.der");
@@ -307,7 +307,7 @@ pub fn invalid_subject_alt_names() {
 
 #[cfg(feature = "alloc")]
 #[test]
-pub fn wildcard_subject_alternative_names() {
+fn wildcard_subject_alternative_names() {
     // same as netflix ee certificate, but with the last name in the list
     // changed to 'ww*.netflix:com'
     let data = include_bytes!("misc/dns_names_and_wildcards.der");
@@ -358,7 +358,7 @@ fn expect_cert_dns_names(data: &[u8], expected_names: &[&str]) {
 
 #[cfg(feature = "alloc")]
 #[test]
-pub fn no_subject_alt_names() {
+fn no_subject_alt_names() {
     let ee = CertificateDer::from(&include_bytes!("misc/no_subject_alternative_name.der")[..]);
 
     let cert = webpki::EndEntityCert::try_from(&ee)


### PR DESCRIPTION
# Description

This branch reworks the `EndEntityCert`'s `dns_names` helper. Principally it:

* Simplifies the unit testing, and cleans up some misc nits.
* Reworks `dns_names` and the corresponding `subject_name::list_cert_dns_names` fns to be infallible, this better matches how we're ignoring invalid DNS names when validating a subject name since #69.
* Removes the `alloc` requirement for the `dns_names` fn.
* Reworks the name ref types to use `as_str` instead of a `From` impl
* Removes the `GeneralDnsNameRef` type (with the potential to restore as future work c.f. #183)
* Moves the `subject_name::list_cert_dns_names` free-standing fn to be associated with `Cert` and named `valid_dns_names`.

Resolves https://github.com/rustls/webpki/issues/46, replaces https://github.com/rustls/webpki/pull/50