### PR TITLE
properly test build chain call budget

### DIFF
--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -177,15 +177,13 @@ mod tests {
         let issuer = test_utils::make_issuer("Test");
 
         let ee_cert_der = {
-            let mut params = rcgen::CertificateParams::new(vec![DNS_NAME.to_string()]);
+            let mut params = test_utils::end_entity_params(vec![DNS_NAME.to_string()]);
             // construct a certificate that uses `PrintableString` as the
             // common name value, rather than `UTF8String`.
             params.distinguished_name.push(
                 rcgen::DnType::CommonName,
                 rcgen::DnValue::PrintableString("example.com".to_string()),
             );
-            params.is_ca = rcgen::IsCa::ExplicitNoCa;
-            params.alg = test_utils::RCGEN_SIGNATURE_ALG;
             let cert = rcgen::Certificate::from_params(params)
                 .expect("failed to make ee cert (this is a test bug)");
             let bytes = cert

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -174,7 +174,7 @@ mod tests {
     fn printable_string_common_name() {
         const DNS_NAME: &str = "test.example.com";
 
-        let issuer = test_utils::make_issuer("Test", None);
+        let issuer = test_utils::make_issuer("Test");
 
         let ee_cert_der = {
             let mut params = rcgen::CertificateParams::new(vec![DNS_NAME.to_string()]);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -11,6 +11,15 @@ pub(crate) fn make_issuer(
     org_name: impl Into<String>,
     name_constraints: Option<rcgen::NameConstraints>,
 ) -> rcgen::Certificate {
+    let mut params = issuer_params(org_name);
+    params.name_constraints = name_constraints;
+    rcgen::Certificate::from_params(params).unwrap()
+}
+
+/// Populate a [CertificateParams] that describes an unconstrained issuer certificate capable
+/// of signing other certificates and CRLs, with the given `org_name` as an organization distinguished
+/// subject name.
+pub(crate) fn issuer_params(org_name: impl Into<String>) -> rcgen::CertificateParams {
     let mut ca_params = rcgen::CertificateParams::new(Vec::new());
     ca_params
         .distinguished_name
@@ -22,8 +31,7 @@ pub(crate) fn make_issuer(
         rcgen::KeyUsagePurpose::CrlSign,
     ];
     ca_params.alg = RCGEN_SIGNATURE_ALG;
-    ca_params.name_constraints = name_constraints;
-    rcgen::Certificate::from_params(ca_params).unwrap()
+    ca_params
 }
 
 pub(crate) fn make_end_entity(issuer: &rcgen::Certificate) -> CertificateDer<'static> {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -2,10 +2,8 @@
 
 use crate::types::CertificateDer;
 
-/// Signature algorithm used by certificates generated using `make_issuer` and
-/// `make_end_entity`. This is exported as a constant so that tests can use the
-/// same algorithm when generating certificates using `rcgen`.
-pub(crate) static RCGEN_SIGNATURE_ALG: &rcgen::SignatureAlgorithm = &rcgen::PKCS_ECDSA_P256_SHA256;
+/// Signature algorithm used by certificates and parameters generated using the test utils helpers.
+static RCGEN_SIGNATURE_ALG: &rcgen::SignatureAlgorithm = &rcgen::PKCS_ECDSA_P256_SHA256;
 
 pub(crate) fn make_issuer(org_name: impl Into<String>) -> rcgen::Certificate {
     rcgen::Certificate::from_params(issuer_params(org_name)).unwrap()

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,13 +1,12 @@
-#[cfg(feature = "alloc")]
+#![cfg(feature = "alloc")]
+
 use crate::types::CertificateDer;
 
 /// Signature algorithm used by certificates generated using `make_issuer` and
 /// `make_end_entity`. This is exported as a constant so that tests can use the
 /// same algorithm when generating certificates using `rcgen`.
-#[cfg(feature = "alloc")]
 pub(crate) static RCGEN_SIGNATURE_ALG: &rcgen::SignatureAlgorithm = &rcgen::PKCS_ECDSA_P256_SHA256;
 
-#[cfg(feature = "alloc")]
 pub(crate) fn make_issuer(
     org_name: impl Into<String>,
     name_constraints: Option<rcgen::NameConstraints>,
@@ -27,7 +26,6 @@ pub(crate) fn make_issuer(
     rcgen::Certificate::from_params(ca_params).unwrap()
 }
 
-#[cfg(feature = "alloc")]
 pub(crate) fn make_end_entity(issuer: &rcgen::Certificate) -> CertificateDer<'static> {
     let mut ee_params = rcgen::CertificateParams::new(vec!["example.com".to_string()]);
     ee_params.is_ca = rcgen::IsCa::ExplicitNoCa;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -7,13 +7,8 @@ use crate::types::CertificateDer;
 /// same algorithm when generating certificates using `rcgen`.
 pub(crate) static RCGEN_SIGNATURE_ALG: &rcgen::SignatureAlgorithm = &rcgen::PKCS_ECDSA_P256_SHA256;
 
-pub(crate) fn make_issuer(
-    org_name: impl Into<String>,
-    name_constraints: Option<rcgen::NameConstraints>,
-) -> rcgen::Certificate {
-    let mut params = issuer_params(org_name);
-    params.name_constraints = name_constraints;
-    rcgen::Certificate::from_params(params).unwrap()
+pub(crate) fn make_issuer(org_name: impl Into<String>) -> rcgen::Certificate {
+    rcgen::Certificate::from_params(issuer_params(org_name)).unwrap()
 }
 
 /// Populate a [CertificateParams] that describes an unconstrained issuer certificate capable

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -30,13 +30,17 @@ pub(crate) fn issuer_params(org_name: impl Into<String>) -> rcgen::CertificatePa
 }
 
 pub(crate) fn make_end_entity(issuer: &rcgen::Certificate) -> CertificateDer<'static> {
-    let mut ee_params = rcgen::CertificateParams::new(vec!["example.com".to_string()]);
-    ee_params.is_ca = rcgen::IsCa::ExplicitNoCa;
-    ee_params.alg = RCGEN_SIGNATURE_ALG;
     CertificateDer::from(
-        rcgen::Certificate::from_params(ee_params)
+        rcgen::Certificate::from_params(end_entity_params(vec!["example.com".into()]))
             .unwrap()
             .serialize_der_with_signer(issuer)
             .unwrap(),
     )
+}
+
+pub(crate) fn end_entity_params(subject_alt_names: Vec<String>) -> rcgen::CertificateParams {
+    let mut ee_params = rcgen::CertificateParams::new(subject_alt_names);
+    ee_params.is_ca = rcgen::IsCa::ExplicitNoCa;
+    ee_params.alg = RCGEN_SIGNATURE_ALG;
+    ee_params
 }

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -517,7 +517,6 @@ mod tests {
     fn build_degenerate_chain(
         intermediate_count: usize,
         trust_anchor: ChainTrustAnchor,
-        budget: Option<Budget>,
     ) -> ControlFlow<Error, Error> {
         let ca_cert = make_issuer("Bogus Subject");
         let ca_cert_der = CertificateDer::from(ca_cert.serialize_der().unwrap());
@@ -547,7 +546,7 @@ mod tests {
             &trust_anchor,
             &intermediates,
             &make_end_entity(&issuer),
-            budget,
+            None,
         )
         .unwrap_err()
     }
@@ -556,7 +555,7 @@ mod tests {
     #[cfg(feature = "alloc")]
     fn test_too_many_signatures() {
         assert!(matches!(
-            build_degenerate_chain(5, ChainTrustAnchor::NotInChain, None),
+            build_degenerate_chain(5, ChainTrustAnchor::NotInChain),
             ControlFlow::Break(Error::MaximumSignatureChecksExceeded)
         ));
     }
@@ -565,7 +564,7 @@ mod tests {
     #[cfg(feature = "alloc")]
     fn test_too_many_path_calls() {
         assert!(matches!(
-            dbg!(build_degenerate_chain(10, ChainTrustAnchor::InChain, None)),
+            dbg!(build_degenerate_chain(10, ChainTrustAnchor::InChain)),
             ControlFlow::Break(Error::MaximumPathBuildCallsExceeded)
         ));
     }


### PR DESCRIPTION
Previously (https://github.com/rustls/webpki/pull/168) we fixed the test case  that used the `build_degenerate_chain` helper to test the build chain call budget (introduced in https://github.com/rustls/webpki/pull/163) by artificially inflating the signature validation limit. This was crummy for a few reasons:

1. It required faking the budget, both to increase the signature validation limit (to avoid hitting that limit first) and to decrease the build chain call budget (to avoid the test taking ~6s to run).
2. It didn't demonstrate very well why two separate limits are required, as it gave the sense under normal circumstances the signature validation limit would reject the pathological chain.

This branch reworks `build_degenerate_chain` so that it can reproduce a pathological chain that only has quadratic runtime prevented by the build chain call budget. E.g. the signature validation limit is _not_ sufficient for this test case. The test demonstrates this with the default budget for both signature validations and build chain calls.

Along the way I did some small refactoring of the `test_utils` to make it easier to adjust certificate parameters for tests that require that without burdening tests that don't. 