### PR TITLE
Let EndEntityCert deref to Cert

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -123,21 +123,6 @@ impl<'a> Cert<'a> {
         )
     }
 
-    /// Raw DER encoded certificate serial number.
-    pub fn serial(&self) -> &[u8] {
-        self.serial.as_slice_less_safe()
-    }
-
-    /// Raw DER encoded certificate issuer.
-    pub fn issuer(&self) -> &[u8] {
-        self.issuer.as_slice_less_safe()
-    }
-
-    /// Raw DER encoded certificate subject.
-    pub fn subject(&self) -> &[u8] {
-        self.subject.as_slice_less_safe()
-    }
-
     pub(crate) fn valid_dns_names(&self) -> impl Iterator<Item = &str> {
         NameIterator::new(Some(self.subject), self.subject_alt_name).filter_map(|result| {
             let presented_id = match result.ok()? {
@@ -157,6 +142,21 @@ impl<'a> Cert<'a> {
                 }
             }
         })
+    }
+
+    /// Raw DER encoded certificate serial number.
+    pub fn serial(&self) -> &[u8] {
+        self.serial.as_slice_less_safe()
+    }
+
+    /// Raw DER encoded certificate issuer.
+    pub fn issuer(&self) -> &[u8] {
+        self.issuer.as_slice_less_safe()
+    }
+
+    /// Raw DER encoded certificate subject.
+    pub fn subject(&self) -> &[u8] {
+        self.subject.as_slice_less_safe()
     }
 
     /// Returns an iterator over the certificate's cRLDistributionPoints extension values, if any.

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -123,7 +123,14 @@ impl<'a> Cert<'a> {
         )
     }
 
-    pub(crate) fn valid_dns_names(&self) -> impl Iterator<Item = &str> {
+    /// Returns a list of valid DNS names provided in the subject alternative names extension
+    ///
+    /// This function must not be used to implement custom DNS name verification.
+    /// Checking that a certificate is valid for a given subject name should always be done with
+    /// [EndEntityCert::verify_is_valid_for_subject_name].
+    ///
+    /// [EndEntityCert::verify_is_valid_for_subject_name]: crate::EndEntityCert::verify_is_valid_for_subject_name
+    pub fn valid_dns_names(&self) -> impl Iterator<Item = &str> {
         NameIterator::new(Some(self.subject), self.subject_alt_name).filter_map(|result| {
             let presented_id = match result.ok()? {
                 GeneralName::DnsName(presented) => presented,

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -12,6 +12,8 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use core::ops::Deref;
+
 use pki_types::{CertificateDer, SignatureVerificationAlgorithm, TrustAnchor, UnixTime};
 
 use crate::crl::RevocationOptions;
@@ -68,10 +70,6 @@ impl<'a> TryFrom<&'a CertificateDer<'a>> for EndEntityCert<'a> {
 }
 
 impl<'a> EndEntityCert<'a> {
-    pub(super) fn inner(&self) -> &cert::Cert {
-        &self.inner
-    }
-
     /// Verifies that the end-entity certificate is valid for use against the
     /// specified Extended Key Usage (EKU).
     ///
@@ -155,6 +153,14 @@ impl<'a> EndEntityCert<'a> {
     /// [EndEntityCert::verify_is_valid_for_subject_name].
     pub fn dns_names(&'a self) -> impl Iterator<Item = &'a str> {
         self.inner.valid_dns_names()
+    }
+}
+
+impl<'a> Deref for EndEntityCert<'a> {
+    type Target = cert::Cert<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -145,15 +145,6 @@ impl<'a> EndEntityCert<'a> {
             untrusted::Input::from(signature),
         )
     }
-
-    /// Returns a list of valid DNS names provided in the subject alternative names extension
-    ///
-    /// This function must not be used to implement custom DNS name verification.
-    /// Checking that a certificate is valid for a given subject name should always be done with
-    /// [EndEntityCert::verify_is_valid_for_subject_name].
-    pub fn dns_names(&'a self) -> impl Iterator<Item = &'a str> {
-        self.inner.valid_dns_names()
-    }
 }
 
 impl<'a> Deref for EndEntityCert<'a> {
@@ -215,7 +206,7 @@ mod tests {
         let cert =
             EndEntityCert::try_from(der).expect("should parse end entity certificate correctly");
 
-        let mut names = cert.dns_names();
+        let mut names = cert.valid_dns_names();
         assert_eq!(names.next(), Some(name));
         assert_eq!(names.next(), None);
     }

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -23,7 +23,6 @@ pub(crate) fn verify_cert_dns_name(
     cert: &crate::EndEntityCert,
     dns_name: DnsNameRef,
 ) -> Result<(), Error> {
-    let cert = cert.inner();
     let dns_name = untrusted::Input::from(dns_name.as_str().as_bytes());
     NameIterator::new(Some(cert.subject), cert.subject_alt_name)
         .find_map(|result| {
@@ -64,7 +63,7 @@ pub(crate) fn verify_cert_subject_name(
         // IP addresses are not compared against the subject field;
         // only against Subject Alternative Names.
         None,
-        cert.inner().subject_alt_name,
+        cert.subject_alt_name,
     )
     .find_map(|result| {
         let name = match result {

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -707,7 +707,7 @@ mod tests {
         }
         .build_chain_inner(
             &PathNode {
-                cert: cert.inner(),
+                cert: &cert,
                 issued: None,
             },
             time,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -319,5 +319,5 @@ fn expect_cert_dns_names<'name>(
     let cert = webpki::EndEntityCert::try_from(&der)
         .expect("should parse end entity certificate correctly");
 
-    assert!(cert.dns_names().eq(expected_names))
+    assert!(cert.valid_dns_names().eq(expected_names))
 }


### PR DESCRIPTION
Avoids duplication and seems generally right. I think this would also make sense in the context of #174.