### PR TITLE
v0.101.6 release prep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.101.5"
+version = "0.101.6"
 
 include = [
     "Cargo.toml",

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -43,7 +43,6 @@ pub trait CertRevocationList: Sealed {
         &self,
         supported_sig_algs: &[&SignatureAlgorithm],
         issuer_spki: &[u8],
-        budget: &mut Budget,
     ) -> Result<(), Error>;
 }
 
@@ -87,13 +86,12 @@ impl CertRevocationList for OwnedCertRevocationList {
         &self,
         supported_sig_algs: &[&SignatureAlgorithm],
         issuer_spki: &[u8],
-        budget: &mut Budget,
     ) -> Result<(), Error> {
         signed_data::verify_signed_data(
             supported_sig_algs,
             untrusted::Input::from(issuer_spki),
             &self.signed_data.borrow(),
-            budget,
+            &mut Budget::default(),
         )
     }
 }
@@ -333,13 +331,12 @@ impl CertRevocationList for BorrowedCertRevocationList<'_> {
         &self,
         supported_sig_algs: &[&SignatureAlgorithm],
         issuer_spki: &[u8],
-        budget: &mut Budget,
     ) -> Result<(), Error> {
         signed_data::verify_signed_data(
             supported_sig_algs,
             untrusted::Input::from(issuer_spki),
             &self.signed_data,
-            budget,
+            &mut Budget::default(),
         )
     }
 }


### PR DESCRIPTION
# Description

This branch targets the `rel-0.101` release branch to make a point release fixing https://github.com/rustls/webpki/issues/185.

## Proposed Release Notes

* The `CertificateRevocationList` trait's `verify_signature` `Budget` argument was removed. This was a semver incompatible change mistakenly introduced in v0.101.5.