### PR TITLE
Cargo: remove rcgen git patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,8 @@ base64 = "0.21"
 bencher = "0.1.5"
 bzip2 = "0.4.4"
 once_cell = "1.17.2"
-rcgen = { version = "0.11.1", default-features = false }
+# TODO(XXX): Switch rcgen back to default-features=false after rcgen#1498 is fixed.
+rcgen = { version = "0.11.2", features = ["pem"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
@@ -107,7 +108,3 @@ codegen-units = 1
 name = "benchmarks"
 path = "benches/benchmark.rs"
 harness = false
-
-[patch.crates-io]
-# TODO(XXX): Remove this once rcgen has cut a release w/ CRL support included.
-rcgen = { git = 'https://github.com/est31/rcgen.git', rev = '83e548a06848d923eada1ac66d1a912735b67e79' }

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -85,6 +85,7 @@ fn generate_crl(revoked_count: usize) -> Vec<u8> {
         crl_number: SerialNumber::from(1234),
         alg: &PKCS_ECDSA_P256_SHA256,
         key_identifier_method: KeyIdMethod::Sha256,
+        issuing_distribution_point: None,
         revoked_certs,
     };
     let crl = CertificateRevocationList::from_params(crl).unwrap();


### PR DESCRIPTION
The `rcgen` crate has cut a 0.11.2 release that includes the CRL functionality we were using a Cargo patch to depend on previously. This commit removes the patch, fixes a breakage in the CRL benchmark, and updates the `Cargo.toml` file.

We temporarily include the "pem" feature to avoid a build breakage introduced in 0.11.2 yet to be fixed upstream (https://github.com/rustls/rcgen/issues/161).