### PR TITLE
crl: rm Budget from verify_signature fn

### DIFF
--- a/src/crl/mod.rs
+++ b/src/crl/mod.rs
@@ -140,7 +140,11 @@ impl<'a> RevocationOptions<'a> {
         // TODO(XXX): consider whether we can refactor so this happens once up-front, instead
         //            of per-lookup.
         //            https://github.com/rustls/webpki/issues/81
-        crl.verify_signature(supported_sig_algs, issuer_spki.as_slice_less_safe(), budget)
+        // Note: The `verify_signature` method is part of a public trait in the exported API.
+        //       We can't add a budget argument to that fn in a semver compatible way and so must
+        //       consume signature budget here before calling verify_signature.
+        budget.consume_signature()?;
+        crl.verify_signature(supported_sig_algs, issuer_spki.as_slice_less_safe())
             .map_err(crl_signature_err)?;
 
         // Verify that if the issuer has a KeyUsage bitstring it asserts cRLSign.

--- a/src/crl/types.rs
+++ b/src/crl/types.rs
@@ -38,7 +38,6 @@ pub trait CertRevocationList: Sealed + Debug {
         &self,
         supported_sig_algs: &[&dyn SignatureVerificationAlgorithm],
         issuer_spki: &[u8],
-        budget: &mut Budget,
     ) -> Result<(), Error>;
 }
 
@@ -86,13 +85,12 @@ impl CertRevocationList for OwnedCertRevocationList {
         &self,
         supported_sig_algs: &[&dyn SignatureVerificationAlgorithm],
         issuer_spki: &[u8],
-        budget: &mut Budget,
     ) -> Result<(), Error> {
         signed_data::verify_signed_data(
             supported_sig_algs,
             untrusted::Input::from(issuer_spki),
             &self.signed_data.borrow(),
-            budget,
+            &mut Budget::default(),
         )
     }
 }
@@ -230,13 +228,12 @@ impl CertRevocationList for BorrowedCertRevocationList<'_> {
         &self,
         supported_sig_algs: &[&dyn SignatureVerificationAlgorithm],
         issuer_spki: &[u8],
-        budget: &mut Budget,
     ) -> Result<(), Error> {
         signed_data::verify_signed_data(
             supported_sig_algs,
             untrusted::Input::from(issuer_spki),
             &self.signed_data,
-            budget,
+            &mut Budget::default(),
         )
     }
 }

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -181,7 +181,7 @@ fn check_signed_chain_name_constraints(
     Ok(())
 }
 
-pub struct Budget {
+pub(crate) struct Budget {
     signatures: usize,
     build_chain_calls: usize,
     name_constraint_comparisons: usize,


### PR DESCRIPTION
## Description

The `Budget` type is a crate-internal detail that shouldn't be exposed outside of the crate. It only makes sense in the context of path path building.

This commit removes the `Budget` argument from the public `CertRevocationList` trait's `verify_signature` fn.

See https://github.com/rustls/webpki/pull/186 for a discussion of rejected alternative solutions.

