### PR TITLE
Cargo: restore rcgen w/ no-default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,8 +83,7 @@ base64 = "0.21"
 bencher = "0.1.5"
 bzip2 = "0.4.4"
 once_cell = "1.17.2"
-# TODO(XXX): Switch rcgen back to default-features=false after rcgen#1498 is fixed.
-rcgen = { version = "0.11.2", features = ["pem"] }
+rcgen = { version = "0.11.3", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 


### PR DESCRIPTION
Rcgen 0.11.3 has been released and fixed the semver breakage that required temporarily using the `pem` feature.