### PR TITLE
v0.101.7 preparation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.60"
+          toolchain: "1.61"
       - run: cargo check --lib --all-features
 
   cross:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.101.6"
+version = "0.101.7"
 
 include = [
     "Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ untrusted = "0.9"
 base64 = "0.21"
 bencher = "0.1.5"
 once_cell = "1.17.2"
-rcgen = { version = "0.11.1", default-features = false }
+rcgen = { version = "0.11.3", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
@@ -98,7 +98,3 @@ codegen-units = 1
 name = "benchmarks"
 path = "benches/benchmark.rs"
 harness = false
-
-[patch.crates-io]
-# TODO(XXX): Remove this once rcgen has cut a release w/ CRL support included.
-rcgen = { git = 'https://github.com/est31/rcgen.git', rev = '83e548a06848d923eada1ac66d1a912735b67e79' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 categories = ["cryptography", "no-std"]
 description = "Web PKI X.509 Certificate Verification."
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.61"
 license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,8 @@ alloc = ["ring/alloc"]
 std = ["alloc"]
 
 [dependencies]
-ring = { version = "0.16.19", default-features = false }
-untrusted = "0.7.1"
+ring = { version = "0.17", default-features = false }
+untrusted = "0.9"
 
 [dev-dependencies]
 base64 = "0.21"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -85,6 +85,7 @@ fn generate_crl(revoked_count: usize) -> Vec<u8> {
         crl_number: SerialNumber::from(1234),
         alg: &PKCS_ECDSA_P256_SHA256,
         key_identifier_method: KeyIdMethod::Sha256,
+        issuing_distribution_point: None,
         revoked_certs,
     };
     let crl = CertificateRevocationList::from_params(crl).unwrap();

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -15,7 +15,7 @@
 use crate::der::Tag;
 use crate::signed_data::SignedData;
 use crate::x509::{remember_extension, set_extension_once, Extension};
-use crate::{der, Error};
+use crate::{der, public_values_eq, Error};
 
 /// An enumeration indicating whether a [`Cert`] is a leaf end-entity cert, or a linked
 /// list node from the CA `Cert` to a child `Cert` it issued.
@@ -70,7 +70,7 @@ impl<'a> Cert<'a> {
             // TODO: In mozilla::pkix, the comparison is done based on the
             // normalized value (ignoring whether or not there is an optional NULL
             // parameter for RSA-based algorithms), so this may be too strict.
-            if signature != signed_data.algorithm {
+            if !public_values_eq(signature, signed_data.algorithm) {
                 return Err(Error::SignatureAlgorithmMismatch);
             }
 

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -17,7 +17,7 @@ use crate::der::Tag;
 use crate::signed_data::{self, SignedData};
 use crate::verify_cert::Budget;
 use crate::x509::{remember_extension, set_extension_once, Extension};
-use crate::{der, Error, SignatureAlgorithm, Time};
+use crate::{der, public_values_eq, Error, SignatureAlgorithm, Time};
 
 #[cfg(feature = "alloc")]
 use std::collections::HashMap;
@@ -155,7 +155,7 @@ impl<'a> BorrowedCertRevocationList<'a> {
             //   This field MUST contain the same algorithm identifier as the
             //   signatureAlgorithm field in the sequence CertificateList
             let signature = der::expect_tag_and_get_value(tbs_cert_list, Tag::Sequence)?;
-            if signature != signed_data.algorithm {
+            if !public_values_eq(signature, signed_data.algorithm) {
                 return Err(Error::SignatureAlgorithmMismatch);
             }
 

--- a/src/der.rs
+++ b/src/der.rs
@@ -426,8 +426,8 @@ mod tests {
 
         // Only 0x00 and 0xff are accepted values
         assert_eq!(
-            Err(Error::BadDer),
-            optional_boolean(&mut bytes_reader(&[0x01, 0x01, 0x42]))
+            optional_boolean(&mut bytes_reader(&[0x01, 0x01, 0x42])).unwrap_err(),
+            Error::BadDer,
         );
 
         // True
@@ -443,33 +443,35 @@ mod tests {
 
         // Unexpected type
         assert_eq!(
-            Err(Error::BadDer),
-            bit_string_with_no_unused_bits(&mut bytes_reader(&[0x01, 0x01, 0xff]))
+            bit_string_with_no_unused_bits(&mut bytes_reader(&[0x01, 0x01, 0xff])).unwrap_err(),
+            Error::BadDer,
         );
 
         // Unexpected nonexistent type
         assert_eq!(
-            Err(Error::BadDer),
-            bit_string_with_no_unused_bits(&mut bytes_reader(&[0x42, 0xff, 0xff]))
+            bit_string_with_no_unused_bits(&mut bytes_reader(&[0x42, 0xff, 0xff])).unwrap_err(),
+            Error::BadDer,
         );
 
         // Unexpected empty input
         assert_eq!(
-            Err(Error::BadDer),
-            bit_string_with_no_unused_bits(&mut bytes_reader(&[]))
+            bit_string_with_no_unused_bits(&mut bytes_reader(&[])).unwrap_err(),
+            Error::BadDer,
         );
 
         // Valid input with non-zero unused bits
         assert_eq!(
-            Err(Error::BadDer),
             bit_string_with_no_unused_bits(&mut bytes_reader(&[0x03, 0x03, 0x04, 0x12, 0x34]))
+                .unwrap_err(),
+            Error::BadDer,
         );
 
         // Valid input
         assert_eq!(
-            untrusted::Input::from(&[0x12, 0x34]),
             bit_string_with_no_unused_bits(&mut bytes_reader(&[0x03, 0x03, 0x00, 0x12, 0x34]))
                 .unwrap()
+                .as_slice_less_safe(),
+            &[0x12, 0x34],
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,3 +92,7 @@ pub use {
     },
     subject_name::{DnsName, IpAddr},
 };
+
+fn public_values_eq(a: untrusted::Input<'_>, b: untrusted::Input<'_>) -> bool {
+    a.as_slice_less_safe() == b.as_slice_less_safe()
+}

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -13,7 +13,7 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::verify_cert::Budget;
-use crate::{der, Error};
+use crate::{der, public_values_eq, Error};
 use ring::signature;
 
 #[cfg(feature = "alloc")]
@@ -377,7 +377,7 @@ struct AlgorithmIdentifier {
 
 impl AlgorithmIdentifier {
     fn matches_algorithm_id_value(&self, encoded: untrusted::Input) -> bool {
-        encoded == self.asn1_id_value
+        public_values_eq(encoded, self.asn1_id_value)
     }
 }
 

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -528,10 +528,12 @@ mod tests {
         let tsd = parse_test_signed_data(file_contents);
         let signature = untrusted::Input::from(&tsd.signature);
         assert_eq!(
-            Err(expected_error),
-            signature.read_all(Error::BadDer, |input| {
-                der::bit_string_with_no_unused_bits(input)
-            })
+            signature
+                .read_all(Error::BadDer, |input| {
+                    der::bit_string_with_no_unused_bits(input)
+                })
+                .unwrap_err(),
+            expected_error
         );
     }
 
@@ -549,10 +551,11 @@ mod tests {
         let tsd = parse_test_signed_data(file_contents);
         let spki = untrusted::Input::from(&tsd.spki);
         assert_eq!(
-            Err(expected_error),
             spki.read_all(Error::BadDer, |input| {
                 der::expect_tag_and_get_value(input, der::Tag::Sequence)
             })
+            .unwrap_err(),
+            expected_error,
         );
     }
 


### PR DESCRIPTION
# Description

This branch targets the `rel-0.101` release branch to make a point release to upgrade to *ring* 0.17. This will unblock a Rustls 0.21 point release that does the same.

This involves bringing the work from https://github.com/rustls/webpki/pull/193 onto the rel-0.101 branch. I didn't cherry-pick the commits directly because the restructuring of the modules in `main` made it more challenging to resolve conflicts than to re-implement the changes wholesale.

The `rcgen` update (from https://github.com/rustls/webpki/pull/189 and https://github.com/rustls/webpki/pull/195) isn't mentioned in the proposed release notes since it's a dev dependency. We also don't typically mention MSRV updates, so its omitted as well.

## Proposed Release Notes

* Upgrades `*ring*` to 0.17, and `untrusted` to 0.9. _Note: since `unstrusted` appears in the `Error` API this may be a breaking change for applications using two `untrusted` versions_.