### PR TITLE
Use cargo-check-external-types to control type leakage in public API 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,26 @@ jobs:
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
 
+  check-external-types:
+    name: Validate external types appearing in public API
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2023-10-10
+          # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
+
+      - run: cargo install --locked cargo-check-external-types
+
+      - name: run cargo-check-external-types
+        run: cargo check-external-types
+
   coverage:
     name: Measure coverage
     runs-on: ubuntu-20.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,12 @@ include = [
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "rustls_pki_types::*",
+    "rustls_pki_types", # To allow re-export.
+]
+
 [lib]
 name = "webpki"
 

--- a/src/crl/types.rs
+++ b/src/crl/types.rs
@@ -406,7 +406,7 @@ impl<'a> IssuingDistributionPoint<'a> {
         //       to unwrap a Tag::Boolean constructed value.
         fn decode_bool(value: untrusted::Input) -> Result<bool, Error> {
             let mut reader = untrusted::Reader::new(value);
-            let value = reader.read_byte()?;
+            let value = reader.read_byte().map_err(der::end_of_input_err)?;
             if !reader.at_end() {
                 return Err(Error::BadDer);
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -292,12 +292,6 @@ impl fmt::Display for Error {
 #[cfg(feature = "std")]
 impl ::std::error::Error for Error {}
 
-impl From<untrusted::EndOfInput> for Error {
-    fn from(_: untrusted::EndOfInput) -> Self {
-        Error::BadDer
-    }
-}
-
 /// Trailing data was found while parsing DER-encoded input for the named type.
 #[allow(missing_docs)]
 #[non_exhaustive]


### PR DESCRIPTION
Like https://github.com/rustls/rustls/pull/1535, this branch brings the [cargo-check-external-types](https://github.com/awslabs/cargo-check-external-types) tool to the webpki repo. This will help us catch unintended leaking of types from dependencies into the public API. One such occurrence is caught by the tool and fixed alongside adding it to CI.