### PR TITLE
 derive Debug for RingAlgorithm, AwsLcRsAlgorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.102.0-alpha.7"
+version = "0.102.0-alpha.8"
 
 include = [
     "Cargo.toml",

--- a/src/aws_lc_rs_algs.rs
+++ b/src/aws_lc_rs_algs.rs
@@ -7,6 +7,7 @@ use crate::signed_data::alg_id;
 // so this is very similar to ring_algs.rs.
 
 /// A `SignatureVerificationAlgorithm` implemented using aws-lc-rs.
+#[derive(Debug)]
 struct AwsLcRsAlgorithm {
     public_key_alg_id: AlgorithmIdentifier,
     signature_alg_id: AlgorithmIdentifier,

--- a/src/ring_algs.rs
+++ b/src/ring_algs.rs
@@ -18,6 +18,7 @@ use ring::signature;
 use crate::signed_data::alg_id;
 
 /// A `SignatureVerificationAlgorithm` implemented using *ring*.
+#[derive(Debug)]
 struct RingAlgorithm {
     public_key_alg_id: AlgorithmIdentifier,
     signature_alg_id: AlgorithmIdentifier,


### PR DESCRIPTION
The `SignatureVerificationAlgorithm` in pki-types was changed to have a `Debug` bound (https://github.com/rustls/pki-types/pull/13), so these type needs to be `Debug` to implement the trait.
