### PR TITLE
Prepare v0.102.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.102.0-alpha.8"
+version = "0.102.0"
 
 include = [
     "Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ std = ["alloc", "pki-types/std"]
 
 [dependencies]
 aws-lc-rs = { version = "1.0.0", optional = true }
-pki-types = { package = "rustls-pki-types", version = "0.2.2", default-features = false }
+pki-types = { package = "rustls-pki-types", version = "1", default-features = false }
 ring = { version = "0.17", default-features = false, optional = true }
 untrusted = "0.9"
 


### PR DESCRIPTION
Draft release note headlines (vs 0.101.x):

* **Certificate revocation list (CRL) support**. The default certificate verifier used in rustls can now be configured with CRLs to control revocation of client and server certificates.
* **Extensible and observable path building**. This crate now returns an example of a found certificate path, and optionally allows  callers to reject paths to continue the search.
* **Improving API stability.** This crate now uses types from [rustls-pki-types](https://crates.io/crates/rustls-pki-types); we expect this to reduce the number of breaking changes in rustls ecosystem.
* **Pluggable crypto providers.** This crate can now depend on signature verification algorithms provided externally. *ring* is now an optional (but default) dependency, and [aws-lc-rs](https://crates.io/crates/aws-lc-rs) is a new optional dependency.