### PR TITLE
cert: fix clippy get_first finding

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -618,7 +618,7 @@ mod tests {
         // There should be two distribution points present.
         let (point_a, point_b): (&CrlDistributionPoint, &CrlDistributionPoint) = (
             crl_distribution_points
-                .get(0)
+                .first()
                 .expect("missing first distribution point"),
             crl_distribution_points
                 .get(1)


### PR DESCRIPTION
Scheduled CI tasks [started failing](https://github.com/cpu/webpki/actions/runs/7350078635/job/20030735305) yesterday with the update to the just-released Rust 1.75 from a `clippy` finding:

```
error: accessing first element with `crl_distribution_points.get(0)`
   --> src/cert.rs:620:13
    |
620 | /             crl_distribution_points
621 | |                 .get(0)
    | |_______________________^ help: try: `crl_distribution_points.first()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#get_first
    = note: `-D clippy::get-first` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::get_first)]`
```