### PR TITLE
Prepare 0.102.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.102.0"
+version = "0.102.1"
 
 include = [
     "Cargo.toml",


### PR DESCRIPTION
Draft release notes:

* **Added `webpki::aws_lc_rs::ECDSA_P521_SHA512`**: support for P521-SHA512 signature verification.