### PR TITLE
small nightly clippy fixes

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -408,7 +408,7 @@ mod tests {
         // We expect the distribution point name to be a sequence of GeneralNames, not a name
         // relative to the CRL issuer.
         let names = match distribution_point_name {
-            DistributionPointName::NameRelativeToCrlIssuer(_) => {
+            DistributionPointName::NameRelativeToCrlIssuer => {
                 panic!("unexpected name relative to crl issuer")
             }
             DistributionPointName::FullName(names) => names,
@@ -566,12 +566,10 @@ mod tests {
             .expect("missing distribution point name");
 
         // We expect the distribution point name to be a name relative to the CRL issuer.
-        match distribution_point_name {
-            DistributionPointName::NameRelativeToCrlIssuer(name) => {
-                assert!(!name.is_empty());
-            }
-            DistributionPointName::FullName(_) => panic!("unexpected full name sequence"),
-        };
+        assert!(matches!(
+            distribution_point_name,
+            DistributionPointName::NameRelativeToCrlIssuer
+        ));
     }
 
     #[test]
@@ -633,7 +631,7 @@ mod tests {
                 .expect("failed to parse distribution point names")
                 .expect("missing distribution point name")
             {
-                DistributionPointName::NameRelativeToCrlIssuer(_) => {
+                DistributionPointName::NameRelativeToCrlIssuer => {
                     panic!("unexpected relative name")
                 }
                 DistributionPointName::FullName(names) => names,

--- a/src/crl/types.rs
+++ b/src/crl/types.rs
@@ -538,7 +538,7 @@ impl<'a> IssuingDistributionPoint<'a> {
         use DistributionPointName::*;
         match result.names() {
             Ok(Some(FullName(_))) => Ok(result),
-            Ok(Some(NameRelativeToCrlIssuer(_))) | Ok(None) => {
+            Ok(Some(NameRelativeToCrlIssuer)) | Ok(None) => {
                 Err(Error::UnsupportedCrlIssuingDistributionPoint)
             }
             Err(_) => Err(Error::MalformedExtensions),
@@ -944,7 +944,7 @@ mod tests {
             .expect("failed to parse distribution point names")
             .expect("missing distribution point name");
         let uri = match dp_name {
-            DistributionPointName::NameRelativeToCrlIssuer(_) => {
+            DistributionPointName::NameRelativeToCrlIssuer => {
                 panic!("unexpected relative dp name")
             }
             DistributionPointName::FullName(general_names) => {

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -111,7 +111,7 @@ fn check_presented_id_conforms_to_constraints(
                     dns_name::presented_id_matches_reference_id(name, IdRole::NameConstraint, base)
                 }
 
-                (GeneralName::DirectoryName(_), GeneralName::DirectoryName(_)) => Ok(
+                (GeneralName::DirectoryName, GeneralName::DirectoryName) => Ok(
                     // Reject any uses of directory name constraints; we don't implement this.
                     //
                     // Rejecting everything technically confirms to RFC5280:
@@ -237,8 +237,8 @@ impl<'a> Iterator for NameIterator<'a> {
             }
         }
 
-        if let Some(subject_directory_name) = self.subject_directory_name.take() {
-            return Some(Ok(GeneralName::DirectoryName(subject_directory_name)));
+        if self.subject_directory_name.take().is_some() {
+            return Some(Ok(GeneralName::DirectoryName));
         }
 
         None
@@ -253,7 +253,7 @@ impl<'a> Iterator for NameIterator<'a> {
 #[derive(Clone, Copy)]
 pub(crate) enum GeneralName<'a> {
     DnsName(untrusted::Input<'a>),
-    DirectoryName(untrusted::Input<'a>),
+    DirectoryName,
     IpAddress(untrusted::Input<'a>),
     UniformResourceIdentifier(untrusted::Input<'a>),
 
@@ -282,7 +282,7 @@ impl<'a> FromDer<'a> for GeneralName<'a> {
         let (tag, value) = der::read_tag_and_get_value(reader)?;
         Ok(match tag {
             DNS_NAME_TAG => DnsName(value),
-            DIRECTORY_NAME_TAG => DirectoryName(value),
+            DIRECTORY_NAME_TAG => DirectoryName,
             IP_ADDRESS_TAG => IpAddress(value),
             UNIFORM_RESOURCE_IDENTIFIER_TAG => UniformResourceIdentifier(value),
 

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -86,7 +86,7 @@ pub(crate) fn remember_extension(
 /// [^1]: <https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13>
 pub(crate) enum DistributionPointName<'a> {
     /// The distribution point name is a relative distinguished name, relative to the CRL issuer.
-    NameRelativeToCrlIssuer(untrusted::Input<'a>),
+    NameRelativeToCrlIssuer,
     /// The distribution point name is a sequence of [GeneralName] items.
     FullName(DerIterator<'a, GeneralName<'a>>),
 }
@@ -102,9 +102,7 @@ impl<'a> FromDer<'a> for DistributionPointName<'a> {
         let (tag, value) = der::read_tag_and_get_value(reader)?;
         match tag {
             FULL_NAME_TAG => Ok(DistributionPointName::FullName(DerIterator::new(value))),
-            NAME_RELATIVE_TO_CRL_ISSUER_TAG => {
-                Ok(DistributionPointName::NameRelativeToCrlIssuer(value))
-            }
+            NAME_RELATIVE_TO_CRL_ISSUER_TAG => Ok(DistributionPointName::NameRelativeToCrlIssuer),
             _ => Err(Error::BadDer),
         }
     }


### PR DESCRIPTION
CI started failing the nightly clippy task ([example](https://github.com/rustls/webpki/actions/runs/7451466705/job/20272649231)) ~yesterday from a couple enum variants where we never accessed the inner fields.

This branch fixes both findings by removing the unused `untrusted::Input` inner fields.