### PR TITLE
fix(der): check at_end before reading tag

### DIFF
--- a/src/der.rs
+++ b/src/der.rs
@@ -271,10 +271,10 @@ pub(crate) fn nested_of_mut<'a>(
 ) -> Result<(), Error> {
     nested(input, outer_tag, error, |outer| {
         loop {
-            nested(outer, inner_tag, error, |inner| decoder(inner))?;
             if outer.at_end() {
                 break;
             }
+            nested(outer, inner_tag, error, |inner| decoder(inner))?;
         }
         Ok(())
     })


### PR DESCRIPTION
When I was testing the inter-op with some old tls implementations(e.g. `tls` impl of `go 1.17`), I found that there's no tag, thus the first read will get an EOF error and be converted into `BadEncoding`.

After changing the `at_end` check before reading, the handshake succeeded.

I'm not familiar with cryptography, could you please help me to check if this is correct. Thanks!