### PR TITLE
Cargo: avoid unused aws-lc-rs default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ ring = ["dep:ring"]
 std = ["alloc", "pki-types/std"]
 
 [dependencies]
-aws-lc-rs = { version = "1.0.0", optional = true }
+aws-lc-rs = { version = "1", optional = true, default-features = false, features = ["aws-lc-sys"] }
 pki-types = { package = "rustls-pki-types", version = "1", default-features = false }
 ring = { version = "0.17", default-features = false, optional = true }
 untrusted = "0.9"


### PR DESCRIPTION
The `aws-lc-rs` crate [defaults to enabling the `ring-io` and `ring-sig-verify` features](https://github.com/aws/aws-lc-rs/blob/067c9486eb117c67a9da977256f1a99bac11bfae/aws-lc-rs/Cargo.toml#L31), but we use neither in this crate. Avoiding these features is beneficial because it prevents the inclusion of a second copy of `untrusted` in the dependency tree.

You can see the presence of the extra `untrusted 0.7.1` in `cargo tree --no-default-features --features=aws_lc_rs` before/after this change:

<details>
<summary>Cargo tree output from `main` prior to this change:</summary>

```
rustls-webpki v0.102.1 (/home/daniel/Code/Rust/webpki)
├── aws-lc-rs v1.6.1
│   ├── aws-lc-sys v0.13.0
│   │   ├── libc v0.2.150
│   │   └── paste v1.0.14 (proc-macro)
│   │   [build-dependencies]
│   │   ├── cmake v0.1.50
│   │   │   └── cc v1.0.83
│   │   │       └── libc v0.2.150
│   │   ├── dunce v1.0.4
│   │   └── fs_extra v1.3.0
│   ├── mirai-annotations v1.12.0
│   ├── paste v1.0.14 (proc-macro)
│   ├── untrusted v0.7.1
│   └── zeroize v1.7.0
├── rustls-pki-types v1.1.0
└── untrusted v0.9.0
```
</details>

<details>
<summary>Cargo tree output from this branch:</summary>

```
rustls-webpki v0.102.1 (/home/daniel/Code/Rust/webpki)
├── aws-lc-rs v1.6.1
│   ├── aws-lc-sys v0.13.0
│   │   ├── libc v0.2.150
│   │   └── paste v1.0.14 (proc-macro)
│   │   [build-dependencies]
│   │   ├── cmake v0.1.50
│   │   │   └── cc v1.0.83
│   │   │       └── libc v0.2.150
│   │   ├── dunce v1.0.4
│   │   └── fs_extra v1.3.0
│   ├── mirai-annotations v1.12.0
│   ├── paste v1.0.14 (proc-macro)
│   └── zeroize v1.7.0
├── rustls-pki-types v1.1.0
└── untrusted v0.9.0
```
</details>

Related: https://github.com/rustls/rustls/pull/1768
