### PR TITLE
Fix nightly compilation

### DIFF
--- a/src/alg_tests.rs
+++ b/src/alg_tests.rs
@@ -21,7 +21,6 @@ use base64::{engine::general_purpose, Engine as _};
 use crate::error::{DerTypeId, Error};
 use crate::verify_cert::Budget;
 use crate::{der, signed_data};
-use alloc::{string::String, vec::Vec};
 
 use super::{
     INVALID_SIGNATURE_FOR_RSA_KEY, OK_IF_RSA_AVAILABLE, SUPPORTED_ALGORITHMS_IN_TESTS,

--- a/src/alg_tests.rs
+++ b/src/alg_tests.rs
@@ -14,6 +14,8 @@
 
 #![allow(clippy::duplicate_mod)]
 
+use std::prelude::v1::*;
+
 use base64::{engine::general_purpose, Engine as _};
 
 use crate::error::{DerTypeId, Error};

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -343,10 +343,6 @@ mod tests {
     use super::*;
     #[cfg(feature = "alloc")]
     use crate::crl::RevocationReason;
-    #[cfg(feature = "alloc")]
-    use crate::error::Error;
-    #[cfg(feature = "alloc")]
-    use crate::subject_name::GeneralName;
     use std::prelude::v1::*;
 
     #[test]

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -347,6 +347,7 @@ mod tests {
     use crate::error::Error;
     #[cfg(feature = "alloc")]
     use crate::subject_name::GeneralName;
+    use std::prelude::v1::*;
 
     #[test]
     // Note: cert::parse_cert is crate-local visibility, and EndEntityCert doesn't expose the

--- a/src/crl/mod.rs
+++ b/src/crl/mod.rs
@@ -250,7 +250,7 @@ mod tests {
         #[cfg(feature = "alloc")]
         {
             let err = result.unwrap_err();
-            println!("{:?}", err.clone());
+            std::println!("{:?}", err.clone());
         }
 
         // It should be possible to build a revocation options builder with defaults.
@@ -263,7 +263,7 @@ mod tests {
         #[cfg(feature = "alloc")]
         {
             // The builder should be debug, and clone when alloc is enabled
-            println!("{:?}", builder);
+            std::println!("{:?}", builder);
             _ = builder.clone();
         }
         let opts = builder.build();
@@ -313,7 +313,7 @@ mod tests {
         // Built revocation options should be debug and clone when alloc is enabled.
         #[cfg(feature = "alloc")]
         {
-            println!("{:?}", opts.clone());
+            std::println!("{:?}", opts.clone());
         }
     }
 }

--- a/src/crl/types.rs
+++ b/src/crl/types.rs
@@ -900,6 +900,8 @@ impl TryFrom<u8> for RevocationReason {
 #[cfg(test)]
 mod tests {
     use pki_types::CertificateDer;
+    use std::prelude::v1::*;
+    use std::println;
 
     use super::*;
     use crate::cert::Cert;

--- a/src/der.rs
+++ b/src/der.rs
@@ -423,6 +423,7 @@ macro_rules! oid {
 #[cfg(test)]
 mod tests {
     use super::DerTypeId;
+    use std::prelude::v1::*;
 
     #[test]
     fn test_optional_boolean() {

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -186,6 +186,7 @@ impl<'a> Deref for EndEntityCert<'a> {
 mod tests {
     use super::*;
     use crate::test_utils;
+    use std::prelude::v1::*;
 
     // This test reproduces https://github.com/rustls/webpki/issues/167 --- an
     // end-entity cert where the common name is a `PrintableString` rather than

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! | `ring` | Enable use of the *ring* crate for cryptography. |
 //! | `aws_lc_rs` | Enable use of the aws-lc-rs crate for cryptography. |
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![warn(unreachable_pub)]
 #![deny(missing_docs, clippy::as_conversions)]
 #![allow(
@@ -39,6 +39,9 @@
 )]
 // Enable documentation for all features on docs.rs
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+#[cfg(any(feature = "std", test))]
+extern crate std;
 
 #[cfg(any(test, feature = "alloc"))]
 #[cfg_attr(test, macro_use)]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "alloc")]
+use std::prelude::v1::*;
 
 use crate::types::CertificateDer;
 

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -12,7 +12,6 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use core::default::Default;
 use core::ops::ControlFlow;
 
 use pki_types::{CertificateDer, SignatureVerificationAlgorithm, TrustAnchor, UnixTime};

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -705,6 +705,8 @@ mod tests {
     use super::*;
     use crate::test_utils::{issuer_params, make_end_entity, make_issuer};
     use crate::trust_anchor::anchor_from_trusted_cert;
+    use std::dbg;
+    use std::prelude::v1::*;
 
     #[test]
     fn eku_key_purpose_id() {


### PR DESCRIPTION
This fixes compilation with nightly, which just got better at detecting redundant imports: https://github.com/rust-lang/rust/pull/117772

Mostly from @cpu/cpu-fix-nightly-clippy