### PR TITLE
v0.102.3, bump aws-lc-rs from 1.6.4 to 1.7.0, MSRV 1.63

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.61"
+          toolchain: "1.63"
       - run: cargo check --locked --lib --all-features
 
   cross:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   rustfmt:
     name: Format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
 
   deny:
     name: Cargo Deny
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
   # Verify that documentation builds.
   rustdoc:
     name: Check for documentation errors
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         rust_channel:
@@ -89,7 +89,7 @@ jobs:
 
   package:
     name: Cargo Package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -141,37 +141,37 @@ jobs:
           - features: # Default
             mode: # debug
             rust_channel: stable
-            host_os: ubuntu-20.04
+            host_os: ubuntu-latest
 
           - features: --features=alloc
             mode: # debug
             rust_channel: stable
-            host_os: ubuntu-20.04
+            host_os: ubuntu-latest
 
           - features: --no-default-features
             mode: # debug
             rust_channel: stable
-            host_os: ubuntu-20.04
+            host_os: ubuntu-latest
 
           - features: --no-default-features --features alloc,std
             mode: # debug
             rust_channel: stable
-            host_os: ubuntu-20.04
+            host_os: ubuntu-latest
 
           - features: --all-features
             mode: --release
             rust_channel: stable
-            host_os: ubuntu-20.04
+            host_os: ubuntu-latest
 
           - features: --all-features
             mode: # debug
             rust_channel: nightly
-            host_os: ubuntu-20.04
+            host_os: ubuntu-latest
 
           - features: --all-features
             mode: # debug
             rust_channel: beta
-            host_os: ubuntu-20.04
+            host_os: ubuntu-latest
 
           - features: --all-features
             mode: # debug
@@ -230,7 +230,7 @@ jobs:
 
   msrv:
     name: MSRV
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -245,7 +245,7 @@ jobs:
 
   cross:
     name: Check cross compilation targets
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -294,7 +294,7 @@ jobs:
 
   coverage:
     name: Measure coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -321,7 +321,7 @@ jobs:
 
   nostd:
     name: Verify that no-std modes do not rely on libstd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # a target without a pre-compiled libstd like this one will catch any use of libstd in the
     # entire dependency graph whereas a target like x86_64-unknown-linux-gnu will not
     env:
@@ -347,7 +347,7 @@ jobs:
 
   feature-powerset:
     name: Feature Powerset
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.6.4"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f379c4e505c0692333bd90a334baa234990faa06bdabefd3261f765946aa920"
+checksum = "5509d663b2c00ee421bda8d6a24d6c42e15970957de1701b8df9f6fbe5707df1"
 dependencies = [
  "aws-lc-sys",
  "mirai-annotations",
@@ -26,11 +26,12 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68aa3d613f42dbf301dbbcaf3dc260805fd33ffd95f6d290ad7231a9e5d877a7"
+checksum = "8d5d317212c2a78d86ba6622e969413c38847b62f48111f8b763af3dac2f9840"
 dependencies = [
  "bindgen",
+ "cc",
  "cmake",
  "dunce",
  "fs_extra",
@@ -105,6 +106,10 @@ name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+dependencies = [
+ "jobserver",
+ "libc",
+]
 
 [[package]]
 name = "cexpr"
@@ -218,6 +223,15 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jobserver"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "aws-lc-rs",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 categories = ["cryptography", "no-std"]
 description = "Web PKI X.509 Certificate Verification."
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.102.2"
+version = "0.102.3"
 
 include = [
     "Cargo.toml",


### PR DESCRIPTION
Replaces https://github.com/rustls/webpki/pull/246  A few additional changes are required above what was in #246:

### proj: MSRV 1.61 -> 1.63

We're seeing more of our deps move to this MSRV or higher (in this case, a transitive dep on `jobserver`) and it's shipped in Debian stable. Time to move our MSRV to 1.63.

### ci: ubuntu-20.04 -> ubuntu-latest

Changing the runner image to `ubuntu-latest` takes a Ubuntu 22.04 image that includes GCC 11. This is notable because the latest [aws-lc-rs build script bails](https://github.com/aws/aws-lc-rs/blob/575f7d0656250e5302f8a9ce2ae34b3d098799b2/aws-lc-sys/builder/cc_builder.rs#L202-L260) when compiled with a GCC version affected by [a nasty `memcpy` bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189). The 20.04 image uses GCC 9 and _is_ affected.

We prefer `ubuntu-latest` in our other repositories so this change should be uncontroversial.

### aws-lc-rs 1.7.0

Updates `aws-lc-rs` from 1.6.4 to 1.7.0 ([diff.rs](https://diff.rs/aws-lc-rs/1.6.4/1.7.0/Cargo.toml)). See [upstream release notes](https://github.com/aws/aws-lc-rs/releases/tag/v1.7.0) for more information. 

## Proposed Release Notes

* Updates aws-lc-rs to [1.7.0](https://github.com/aws/aws-lc-rs/releases/tag/v1.7.0)
* MSRV increased from 1.61 to 1.63



