### PR TITLE
Update Dependabot config to match rustls

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,12 @@ updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      crates-io:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Daily one-by-one semver-incompatible PRs are a PITA.