### PR TITLE
benches: ignore clippy::incompatible_msrv

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::incompatible_msrv)]
+
 use bencher::{benchmark_group, benchmark_main, Bencher};
 use once_cell::sync::Lazy;
 use rcgen::{


### PR DESCRIPTION
The Rust 1.80 release [broke the clippy task](https://github.com/rustls/webpki/actions/runs/8928478989) in CI with clippy findings of the form:

```
warning: current MSRV (Minimum Supported Rust Version) is `1.63.0` but this item is stable since `1.66.0`
   --> benches/benchmark.rs:153:15
    |
153 |     c.iter(|| black_box(assert!(matches!(crl.find_serial(FAKE_SERIAL), Ok(None)))));
    |               ^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incompatible_msrv
    = note: `#[warn(clippy::incompatible_msrv)]` on by default
```

This commit ignores these findings under `benches/benchmark.rs`. We don't offer an MSRV for dev-only benchmarks