### PR TITLE
Cargo: v0.102.3 -> v0.102.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.3"
+version = "0.102.4"
 dependencies = [
  "aws-lc-rs",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.102.3"
+version = "0.102.4"
 
 include = [
     "Cargo.toml",


### PR DESCRIPTION
## Proposed Release Notes

* `RevocationOptionsBuilder` now offers a `with_expiration_policy()` fn for setting an `ExpirationPolicy` that will be used to determine how to handle CRLs that have a `NextUpdate` value in the past. The default behaviour is to ignore the `NextUpdate`. Users wishing to use a stricter policy can do so by specifying `ExpirationPolicy::Enforce`. Revocation checking against an expired CRL will then produce an `Error::CrlExpired` error.
* `EndEntityCert` now offers a `subject_public_key_info()` fn for accessing the RFC 5280 `pki_types::SubjectPublicKeyInfoDer`.
