### PR TITLE
ci: update cargo-check-external-types toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-02-07
+          toolchain: nightly-2024-05-01
           # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
 
       - run: cargo install --locked cargo-check-external-types


### PR DESCRIPTION
The upstream project cut a [0.1.12 release](https://github.com/awslabs/cargo-check-external-types/releases/tag/v0.1.12) that now pins Rust nightly-2024-05-01. This commit updates CI to match.