### PR TITLE
Enable some more warnings on lints

### DIFF
--- a/src/alg_tests.rs
+++ b/src/alg_tests.rs
@@ -370,7 +370,7 @@ fn parse_test_signed_data(file_contents: &[u8]) -> TestSignedData {
 
 use alloc::str::Lines;
 
-fn read_pem_section(lines: &mut Lines, section_name: &str) -> Vec<u8> {
+fn read_pem_section(lines: &mut Lines<'_>, section_name: &str) -> Vec<u8> {
     // Skip comments and header
     let begin_section = format!("-----BEGIN {}-----", section_name);
     loop {

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -177,7 +177,7 @@ impl<'a> Cert<'a> {
 
     /// Get the RFC 5280-compliant [`SubjectPublicKeyInfoDer`] (SPKI) of this [`Cert`].
     #[cfg(feature = "alloc")]
-    pub fn subject_public_key_info(&self) -> SubjectPublicKeyInfoDer {
+    pub fn subject_public_key_info(&self) -> SubjectPublicKeyInfoDer<'static> {
         // Our SPKI representation contains only the content of the RFC 5280 SEQUENCE
         // So we wrap the SPKI contents back into a properly-encoded ASN.1 SEQUENCE
         SubjectPublicKeyInfoDer::from(der::asn1_wrap(
@@ -201,7 +201,7 @@ impl<'a> Cert<'a> {
 
 // mozilla::pkix supports v1, v2, v3, and v4, including both the implicit
 // (correct) and explicit (incorrect) encoding of v1. We allow only v3.
-fn version3(input: &mut untrusted::Reader) -> Result<(), Error> {
+fn version3(input: &mut untrusted::Reader<'_>) -> Result<(), Error> {
     der::nested(
         input,
         der::Tag::ContextSpecificConstructed0,
@@ -417,7 +417,7 @@ mod tests {
 
         // There should be one distribution point present.
         assert_eq!(crl_distribution_points.len(), 1);
-        let crl_distribution_point: &CrlDistributionPoint = crl_distribution_points
+        let crl_distribution_point = crl_distribution_points
             .first()
             .expect("missing distribution point");
 
@@ -449,7 +449,7 @@ mod tests {
 
         // There should be one general name.
         assert_eq!(names.len(), 1);
-        let name: &GeneralName = names.first().expect("missing general name");
+        let name = names.first().expect("missing general name");
 
         // The general name should be a URI matching the expected value.
         match name {
@@ -479,7 +479,7 @@ mod tests {
 
         // There should be one distribution point present.
         assert_eq!(crl_distribution_points.len(), 1);
-        let crl_distribution_point: &CrlDistributionPoint = crl_distribution_points
+        let crl_distribution_point = crl_distribution_points
             .first()
             .expect("missing distribution point");
 
@@ -518,7 +518,7 @@ mod tests {
 
         // There should be one distribution point present.
         assert_eq!(crl_distribution_points.len(), 1);
-        let crl_distribution_point: &CrlDistributionPoint = crl_distribution_points
+        let crl_distribution_point = crl_distribution_points
             .first()
             .expect("missing distribution point");
 
@@ -580,7 +580,7 @@ mod tests {
 
         // There should be one distribution point present.
         assert_eq!(crl_distribution_points.len(), 1);
-        let crl_distribution_point: &CrlDistributionPoint = crl_distribution_points
+        let crl_distribution_point = crl_distribution_points
             .first()
             .expect("missing distribution point");
 
@@ -618,7 +618,7 @@ mod tests {
 
         // There should be one distribution point present.
         assert_eq!(crl_distribution_points.len(), 1);
-        let crl_distribution_point: &CrlDistributionPoint = crl_distribution_points
+        let crl_distribution_point = crl_distribution_points
             .first()
             .expect("missing distribution point");
 
@@ -642,7 +642,7 @@ mod tests {
             .expect("failed to parse distribution points");
 
         // There should be two distribution points present.
-        let (point_a, point_b): (&CrlDistributionPoint, &CrlDistributionPoint) = (
+        let (point_a, point_b) = (
             crl_distribution_points
                 .first()
                 .expect("missing first distribution point"),
@@ -666,7 +666,7 @@ mod tests {
             }
         }
 
-        fn uri_bytes<'a>(name: &'a GeneralName) -> &'a [u8] {
+        fn uri_bytes<'a>(name: &'a GeneralName<'a>) -> &'a [u8] {
             match name {
                 GeneralName::UniformResourceIdentifier(uri) => uri.as_slice_less_safe(),
                 _ => panic!("unexpected name type"),

--- a/src/crl/mod.rs
+++ b/src/crl/mod.rs
@@ -115,9 +115,9 @@ impl<'a> RevocationOptions<'a> {
     pub(crate) fn check(
         &self,
         path: &PathNode<'_>,
-        issuer_subject: untrusted::Input,
-        issuer_spki: untrusted::Input,
-        issuer_ku: Option<untrusted::Input>,
+        issuer_subject: untrusted::Input<'_>,
+        issuer_spki: untrusted::Input<'_>,
+        issuer_ku: Option<untrusted::Input<'_>>,
         supported_sig_algs: &[&dyn SignatureVerificationAlgorithm],
         budget: &mut Budget,
         time: UnixTime,
@@ -185,7 +185,7 @@ enum KeyUsageMode {
 
 impl KeyUsageMode {
     // https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.3
-    fn check(self, input: Option<untrusted::Input>) -> Result<(), Error> {
+    fn check(self, input: Option<untrusted::Input<'_>>) -> Result<(), Error> {
         let bit_string = match input {
             Some(input) => {
                 der::expect_tag(&mut untrusted::Reader::new(input), der::Tag::BitString)?
@@ -286,7 +286,7 @@ mod tests {
 
         // It should be possible to build a revocation options builder with defaults.
         let crl = include_bytes!("../../tests/crls/crl.valid.der");
-        let crl: CertRevocationList = BorrowedCertRevocationList::from_der(&crl[..])
+        let crl = BorrowedCertRevocationList::from_der(&crl[..])
             .unwrap()
             .into();
         let crls = [&crl];

--- a/src/der.rs
+++ b/src/der.rs
@@ -364,7 +364,7 @@ impl<'a> BitStringFlags<'a> {
 //
 // [0]: https://security.stackexchange.com/a/10396
 // [1]: https://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf
-pub(crate) fn bit_string_flags(input: untrusted::Input) -> Result<BitStringFlags<'_>, Error> {
+pub(crate) fn bit_string_flags(input: untrusted::Input<'_>) -> Result<BitStringFlags<'_>, Error> {
     input.read_all(Error::BadDer, |bit_string| {
         // ITU X690-0207 11.2:
         //   "The initial octet shall encode, as an unsigned binary integer with bit 1 as the least
@@ -586,7 +586,7 @@ mod tests {
         );
     }
 
-    fn bytes_reader(bytes: &[u8]) -> untrusted::Reader {
+    fn bytes_reader(bytes: &[u8]) -> untrusted::Reader<'_> {
         return untrusted::Reader::new(untrusted::Input::from(bytes));
     }
 

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -101,7 +101,7 @@ impl<'a> EndEntityCert<'a> {
     pub fn verify_for_usage<'p>(
         &'p self,
         supported_sig_algs: &[&dyn SignatureVerificationAlgorithm],
-        trust_anchors: &'p [TrustAnchor],
+        trust_anchors: &'p [TrustAnchor<'_>],
         intermediate_certs: &'p [CertificateDer<'p>],
         time: UnixTime,
         usage: KeyUsage,

--- a/src/error.rs
+++ b/src/error.rs
@@ -292,7 +292,7 @@ impl From<Error> for ControlFlow<Error, Error> {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,8 @@
     clippy::single_match,
     clippy::single_match_else,
     clippy::type_complexity,
-    clippy::upper_case_acronyms
+    clippy::upper_case_acronyms,
+    clippy::use_self
 )]
 // Enable documentation for all features on docs.rs
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! | `aws_lc_rs` | Enable use of the aws-lc-rs crate for cryptography. |
 
 #![no_std]
-#![warn(unreachable_pub)]
+#![warn(elided_lifetimes_in_paths, unreachable_pub)]
 #![deny(missing_docs, clippy::as_conversions)]
 #![allow(
     clippy::len_without_is_empty,

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -155,8 +155,8 @@ impl<'a> SignedData<'a> {
 /// linearly for matches.
 pub(crate) fn verify_signed_data(
     supported_algorithms: &[&dyn SignatureVerificationAlgorithm],
-    spki_value: untrusted::Input,
-    signed_data: &SignedData,
+    spki_value: untrusted::Input<'_>,
+    signed_data: &SignedData<'_>,
     budget: &mut Budget,
 ) -> Result<(), Error> {
     budget.consume_signature()?;
@@ -210,11 +210,11 @@ pub(crate) fn verify_signed_data(
 
 pub(crate) fn verify_signature(
     signature_alg: &dyn SignatureVerificationAlgorithm,
-    spki_value: untrusted::Input,
-    msg: untrusted::Input,
-    signature: untrusted::Input,
+    spki_value: untrusted::Input<'_>,
+    msg: untrusted::Input<'_>,
+    signature: untrusted::Input<'_>,
 ) -> Result<(), Error> {
-    let spki = der::read_all::<SubjectPublicKeyInfo>(spki_value)?;
+    let spki = der::read_all::<SubjectPublicKeyInfo<'_>>(spki_value)?;
     if signature_alg.public_key_alg_id().as_ref() != spki.algorithm_id_value.as_slice_less_safe() {
         return Err(Error::UnsupportedSignatureAlgorithmForPublicKey);
     }

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -84,7 +84,7 @@ impl<'a> WildcardDnsNameRef<'a> {
 }
 
 impl core::fmt::Debug for WildcardDnsNameRef<'_> {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         f.write_str("WildcardDnsNameRef(\"")?;
 
         // Convert each byte of the underlying ASCII string to a `char` and
@@ -215,9 +215,9 @@ impl core::fmt::Debug for WildcardDnsNameRef<'_> {
 //     incorporated into the spec:
 //     https://www.ietf.org/mail-archive/web/pkix/current/msg21192.html
 pub(super) fn presented_id_matches_reference_id(
-    presented_dns_id: untrusted::Input,
+    presented_dns_id: untrusted::Input<'_>,
     reference_dns_id_role: IdRole,
-    reference_dns_id: untrusted::Input,
+    reference_dns_id: untrusted::Input<'_>,
 ) -> Result<bool, Error> {
     if !is_valid_dns_id(presented_dns_id, IdRole::Presented, Wildcards::Allow) {
         return Err(Error::MalformedDnsIdentifier);
@@ -377,7 +377,7 @@ pub(super) enum IdRole {
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1136616: As an exception to the
 // requirement above, underscores are also allowed in names for compatibility.
 fn is_valid_dns_id(
-    hostname: untrusted::Input,
+    hostname: untrusted::Input<'_>,
     id_role: IdRole,
     allow_wildcards: Wildcards,
 ) -> bool {

--- a/src/subject_name/ip_address.rs
+++ b/src/subject_name/ip_address.rs
@@ -55,8 +55,8 @@ pub(crate) fn verify_ip_address_names(
 //   exactly four octets.  For IP version 6, as specified in
 //   [RFC2460], the octet string MUST contain exactly sixteen octets.
 fn presented_id_matches_reference_id(
-    presented_id: untrusted::Input,
-    reference_id: untrusted::Input,
+    presented_id: untrusted::Input<'_>,
+    reference_id: untrusted::Input<'_>,
 ) -> bool {
     match (presented_id.len(), reference_id.len()) {
         (4, 4) => (),
@@ -89,8 +89,8 @@ fn presented_id_matches_reference_id(
 //     octets C0 00 02 00 FF FF FF 00, representing the CIDR notation
 //     192.0.2.0/24 (mask 255.255.255.0).
 pub(super) fn presented_id_matches_constraint(
-    name: untrusted::Input,
-    constraint: untrusted::Input,
+    name: untrusted::Input<'_>,
+    constraint: untrusted::Input<'_>,
 ) -> Result<bool, Error> {
     match (name.len(), constraint.len()) {
         (4, 8) => (),

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -20,7 +20,7 @@ use crate::verify_cert::{Budget, PathNode};
 
 // https://tools.ietf.org/html/rfc5280#section-4.2.1.10
 pub(crate) fn check_name_constraints(
-    constraints: Option<&mut untrusted::Reader>,
+    constraints: Option<&mut untrusted::Reader<'_>>,
     path: &PathNode<'_>,
     budget: &mut Budget,
 ) -> Result<(), Error> {
@@ -67,9 +67,9 @@ pub(crate) fn check_name_constraints(
 }
 
 fn check_presented_id_conforms_to_constraints(
-    name: GeneralName,
-    permitted_subtrees: Option<untrusted::Input>,
-    excluded_subtrees: Option<untrusted::Input>,
+    name: GeneralName<'_>,
+    permitted_subtrees: Option<untrusted::Input<'_>>,
+    excluded_subtrees: Option<untrusted::Input<'_>>,
     budget: &mut Budget,
 ) -> Option<Result<(), Error>> {
     let subtrees = [

--- a/src/time.rs
+++ b/src/time.rs
@@ -30,7 +30,7 @@ impl<'a> FromDer<'a> for UnixTime {
             Tag::GeneralizedTime
         };
 
-        fn read_digit(inner: &mut untrusted::Reader) -> Result<u64, Error> {
+        fn read_digit(inner: &mut untrusted::Reader<'_>) -> Result<u64, Error> {
             const DIGIT: core::ops::RangeInclusive<u8> = b'0'..=b'9';
             let b = inner.read_byte().map_err(|_| Error::BadDerTime)?;
             if DIGIT.contains(&b) {
@@ -40,7 +40,7 @@ impl<'a> FromDer<'a> for UnixTime {
         }
 
         fn read_two_digits(
-            inner: &mut untrusted::Reader,
+            inner: &mut untrusted::Reader<'_>,
             min: u64,
             max: u64,
         ) -> Result<u64, Error> {

--- a/src/trust_anchor.rs
+++ b/src/trust_anchor.rs
@@ -98,6 +98,6 @@ impl<'a> From<Cert<'a>> for TrustAnchor<'a> {
     }
 }
 
-fn skip(input: &mut untrusted::Reader, tag: der::Tag) -> Result<(), Error> {
+fn skip(input: &mut untrusted::Reader<'_>, tag: der::Tag) -> Result<(), Error> {
     der::expect_tag(input, tag).map(|_| ())
 }

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -62,7 +62,7 @@ pub(crate) fn set_extension_once<T>(
 }
 
 pub(crate) fn remember_extension(
-    extension: &Extension,
+    extension: &Extension<'_>,
     mut handler: impl FnMut(u8) -> Result<(), Error>,
 ) -> Result<(), Error> {
     // ISO arc for standard certificate and CRL extensions.


### PR DESCRIPTION
Triggered by some confusion while looking at https://github.com/rustls/rustls/pull/1954 and getting confused by the lack of lifetimes on `SubjectKeyInfoDer` return values.