### PR TITLE
lib: warn for clippy::use_self

### DIFF
--- a/src/crl/types.rs
+++ b/src/crl/types.rs
@@ -865,7 +865,7 @@ pub enum RevocationReason {
 
 impl RevocationReason {
     /// Return an iterator over all possible [RevocationReason] variants.
-    pub fn iter() -> impl Iterator<Item = RevocationReason> {
+    pub fn iter() -> impl Iterator<Item = Self> {
         use RevocationReason::*;
         [
             Unspecified,
@@ -901,17 +901,17 @@ impl TryFrom<u8> for RevocationReason {
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         // See https://www.rfc-editor.org/rfc/rfc5280#section-5.3.1
         match value {
-            0 => Ok(RevocationReason::Unspecified),
-            1 => Ok(RevocationReason::KeyCompromise),
-            2 => Ok(RevocationReason::CaCompromise),
-            3 => Ok(RevocationReason::AffiliationChanged),
-            4 => Ok(RevocationReason::Superseded),
-            5 => Ok(RevocationReason::CessationOfOperation),
-            6 => Ok(RevocationReason::CertificateHold),
+            0 => Ok(Self::Unspecified),
+            1 => Ok(Self::KeyCompromise),
+            2 => Ok(Self::CaCompromise),
+            3 => Ok(Self::AffiliationChanged),
+            4 => Ok(Self::Superseded),
+            5 => Ok(Self::CessationOfOperation),
+            6 => Ok(Self::CertificateHold),
             // 7 is not used.
-            8 => Ok(RevocationReason::RemoveFromCrl),
-            9 => Ok(RevocationReason::PrivilegeWithdrawn),
-            10 => Ok(RevocationReason::AaCompromise),
+            8 => Ok(Self::RemoveFromCrl),
+            9 => Ok(Self::PrivilegeWithdrawn),
+            10 => Ok(Self::AaCompromise),
             _ => Err(Error::UnsupportedRevocationReason),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -199,7 +199,7 @@ pub enum Error {
 impl Error {
     // Compare the Error with the new error by rank, returning the higher rank of the two as
     // the most specific error.
-    pub(crate) fn most_specific(self, new: Error) -> Error {
+    pub(crate) fn most_specific(self, new: Self) -> Self {
         // Assign an error a numeric value ranking it by specificity.
         if self.rank() >= new.rank() {
             self
@@ -215,55 +215,55 @@ impl Error {
     pub(crate) fn rank(&self) -> u32 {
         match &self {
             // Errors related to certificate validity
-            Error::CertNotValidYet | Error::CertExpired => 290,
-            Error::CertNotValidForName => 280,
-            Error::CertRevoked | Error::UnknownRevocationStatus | Error::CrlExpired => 270,
-            Error::InvalidCrlSignatureForPublicKey | Error::InvalidSignatureForPublicKey => 260,
-            Error::SignatureAlgorithmMismatch => 250,
-            Error::RequiredEkuNotFound => 240,
-            Error::NameConstraintViolation => 230,
-            Error::PathLenConstraintViolated => 220,
-            Error::CaUsedAsEndEntity | Error::EndEntityUsedAsCa => 210,
-            Error::IssuerNotCrlSigner => 200,
+            Self::CertNotValidYet | Self::CertExpired => 290,
+            Self::CertNotValidForName => 280,
+            Self::CertRevoked | Self::UnknownRevocationStatus | Self::CrlExpired => 270,
+            Self::InvalidCrlSignatureForPublicKey | Self::InvalidSignatureForPublicKey => 260,
+            Self::SignatureAlgorithmMismatch => 250,
+            Self::RequiredEkuNotFound => 240,
+            Self::NameConstraintViolation => 230,
+            Self::PathLenConstraintViolated => 220,
+            Self::CaUsedAsEndEntity | Self::EndEntityUsedAsCa => 210,
+            Self::IssuerNotCrlSigner => 200,
 
             // Errors related to supported features used in an invalid way.
-            Error::InvalidCertValidity => 190,
-            Error::InvalidNetworkMaskConstraint => 180,
-            Error::InvalidSerialNumber => 170,
-            Error::InvalidCrlNumber => 160,
+            Self::InvalidCertValidity => 190,
+            Self::InvalidNetworkMaskConstraint => 180,
+            Self::InvalidSerialNumber => 170,
+            Self::InvalidCrlNumber => 160,
 
             // Errors related to unsupported features.
-            Error::UnsupportedCrlSignatureAlgorithmForPublicKey
-            | Error::UnsupportedSignatureAlgorithmForPublicKey => 150,
-            Error::UnsupportedCrlSignatureAlgorithm | Error::UnsupportedSignatureAlgorithm => 140,
-            Error::UnsupportedCriticalExtension => 130,
-            Error::UnsupportedCertVersion => 130,
-            Error::UnsupportedCrlVersion => 120,
-            Error::UnsupportedDeltaCrl => 110,
-            Error::UnsupportedIndirectCrl => 100,
-            Error::UnsupportedNameType => 95,
-            Error::UnsupportedRevocationReason => 90,
-            Error::UnsupportedRevocationReasonsPartitioning => 80,
-            Error::UnsupportedCrlIssuingDistributionPoint => 70,
-            Error::MaximumPathDepthExceeded => 61,
+            Self::UnsupportedCrlSignatureAlgorithmForPublicKey
+            | Self::UnsupportedSignatureAlgorithmForPublicKey => 150,
+            Self::UnsupportedCrlSignatureAlgorithm | Self::UnsupportedSignatureAlgorithm => 140,
+            Self::UnsupportedCriticalExtension => 130,
+            Self::UnsupportedCertVersion => 130,
+            Self::UnsupportedCrlVersion => 120,
+            Self::UnsupportedDeltaCrl => 110,
+            Self::UnsupportedIndirectCrl => 100,
+            Self::UnsupportedNameType => 95,
+            Self::UnsupportedRevocationReason => 90,
+            Self::UnsupportedRevocationReasonsPartitioning => 80,
+            Self::UnsupportedCrlIssuingDistributionPoint => 70,
+            Self::MaximumPathDepthExceeded => 61,
 
             // Errors related to malformed data.
-            Error::MalformedDnsIdentifier => 60,
-            Error::MalformedNameConstraint => 50,
-            Error::MalformedExtensions | Error::TrailingData(_) => 40,
-            Error::ExtensionValueInvalid => 30,
+            Self::MalformedDnsIdentifier => 60,
+            Self::MalformedNameConstraint => 50,
+            Self::MalformedExtensions | Self::TrailingData(_) => 40,
+            Self::ExtensionValueInvalid => 30,
 
             // Generic DER errors.
-            Error::BadDerTime => 20,
-            Error::BadDer => 10,
+            Self::BadDerTime => 20,
+            Self::BadDer => 10,
 
             // Special case errors - not subject to ranking.
-            Error::MaximumSignatureChecksExceeded => 0,
-            Error::MaximumPathBuildCallsExceeded => 0,
-            Error::MaximumNameConstraintComparisonsExceeded => 0,
+            Self::MaximumSignatureChecksExceeded => 0,
+            Self::MaximumPathBuildCallsExceeded => 0,
+            Self::MaximumNameConstraintComparisonsExceeded => 0,
 
             // Default catch all error - should be renamed in the future.
-            Error::UnknownIssuer => 0,
+            Self::UnknownIssuer => 0,
         }
     }
 
@@ -273,9 +273,9 @@ impl Error {
     pub(crate) fn is_fatal(&self) -> bool {
         matches!(
             self,
-            Error::MaximumSignatureChecksExceeded
-                | Error::MaximumPathBuildCallsExceeded
-                | Error::MaximumNameConstraintComparisonsExceeded
+            Self::MaximumSignatureChecksExceeded
+                | Self::MaximumPathBuildCallsExceeded
+                | Self::MaximumNameConstraintComparisonsExceeded
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! | `aws_lc_rs` | Enable use of the aws-lc-rs crate for cryptography. |
 
 #![no_std]
-#![warn(elided_lifetimes_in_paths, unreachable_pub)]
+#![warn(elided_lifetimes_in_paths, unreachable_pub, clippy::use_self)]
 #![deny(missing_docs, clippy::as_conversions)]
 #![allow(
     clippy::len_without_is_empty,
@@ -35,8 +35,7 @@
     clippy::single_match,
     clippy::single_match_else,
     clippy::type_complexity,
-    clippy::upper_case_acronyms,
-    clippy::use_self
+    clippy::upper_case_acronyms
 )]
 // Enable documentation for all features on docs.rs
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -444,14 +444,14 @@ impl KeyUsage {
     ///
     /// As specified in <https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.12>, this does not require the certificate to specify the eKU extension.
     pub const fn server_auth() -> Self {
-        KeyUsage::required_if_present(EKU_SERVER_AUTH)
+        Self::required_if_present(EKU_SERVER_AUTH)
     }
 
     /// Construct a new [`KeyUsage`] as appropriate for client certificate authentication.
     ///
     /// As specified in <>, this does not require the certificate to specify the eKU extension.
     pub const fn client_auth() -> Self {
-        KeyUsage::required_if_present(EKU_CLIENT_AUTH)
+        Self::required_if_present(EKU_CLIENT_AUTH)
     }
 
     /// Construct a new [`KeyUsage`] requiring a certificate to support the specified OID.
@@ -506,8 +506,8 @@ impl ExtendedKeyUsage {
     fn key_purpose_id_equals(&self, value: untrusted::Input<'_>) -> bool {
         public_values_eq(
             match self {
-                ExtendedKeyUsage::Required(eku) => *eku,
-                ExtendedKeyUsage::RequiredIfPresent(eku) => *eku,
+                Self::Required(eku) => *eku,
+                Self::RequiredIfPresent(eku) => *eku,
             }
             .oid_value,
             value,

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -92,7 +92,7 @@ pub(crate) enum DistributionPointName<'a> {
 }
 
 impl<'a> FromDer<'a> for DistributionPointName<'a> {
-    fn from_der(reader: &mut untrusted::Reader<'a>) -> Result<DistributionPointName<'a>, Error> {
+    fn from_der(reader: &mut untrusted::Reader<'a>) -> Result<Self, Error> {
         // RFC 5280 section §4.2.1.13:
         //   When the distributionPoint field is present, it contains either a
         //   SEQUENCE of general names or a single value, nameRelativeToCRLIssuer


### PR DESCRIPTION
This was accidentally added to the `allow` lints instead of the `warn` lints in https://github.com/rustls/webpki/pull/262.