### PR TITLE
Prepare 0.102.5 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.5"
 dependencies = [
  "aws-lc-rs",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.102.4"
+version = "0.102.5"
 
 include = [
     "Cargo.toml",


### PR DESCRIPTION
## Proposed release notes

* `EndEntityCert::subject_public_key_info()` as added in [0.102.4](https://github.com/rustls/webpki/releases/tag/v%2F0.102.4) neglected to specify the return type's lifetime, limiting the visible lifetime to the lifetime of the `EndEntityCert`. The actual lifetime was `'static`; we've made this explicit and enabled warnings for `elided_lifetimes_in_paths` to avoid similar issues in the future.

To support https://github.com/rustls/rustls/pull/1954#discussion_r1660219420.