### PR TITLE
types: avoid markdown footnotes

### DIFF
--- a/src/crl/types.rs
+++ b/src/crl/types.rs
@@ -841,9 +841,9 @@ impl<'a> FromDer<'a> for BorrowedRevokedCert<'a> {
 }
 
 /// Identifies the reason a certificate was revoked.
-/// See RFC 5280 §5.3.1[^1]
+/// See [RFC 5280 §5.3.1][1]
 ///
-/// [^1] <https://www.rfc-editor.org/rfc/rfc5280#section-5.3.1>
+/// [1]: <https://www.rfc-editor.org/rfc/rfc5280#section-5.3.1>
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[allow(missing_docs)] // Not much to add above the code name.
 pub enum RevocationReason {


### PR DESCRIPTION
Nightly rustdoc flags these as non-standard markdown, and they don't render as nicely as just using a link. See also https://github.com/rustls/rustls/pull/2033

Fixes [build errors on main](https://github.com/rustls/webpki/actions/runs/9821191816/job/27116602046).