### PR TITLE
Update deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -28,9 +28,7 @@ license-files = [
 ]
 
 [bans]
-# We don't maintain a fixed Cargo.lock so enforcing
-# `multiple-versions = "deny"` is impractical.
-multiple-versions = "allow"
+multiple-versions = "deny"
 wildcards = "deny"
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,5 @@
 [advisories]
-unmaintained = "deny"
 yanked = "deny"
-notice = "deny"
 
 [licenses]
 allow = [
@@ -10,7 +8,6 @@ allow = [
     "LicenseRef-ring",
     "LicenseRef-webpki",
     "MIT",
-    "Unicode-DFS-2016",
 ]
 confidence-threshold = 1.0
 


### PR DESCRIPTION
cargo-deny got updated and changed some configuration stuff:

```
djc-2021 main webpki $ cargo deny check licenses
error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
  ┌─ /Users/djc/src/webpki/deny.toml:2:1
  │
2 │ unmaintained = "deny"
  │ ━━━━━━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
  ┌─ /Users/djc/src/webpki/deny.toml:4:1
  │
4 │ notice = "deny"
  │ ━━━━━━

2024-08-03 15:03:31 [ERROR] failed to validate configuration file /Users/djc/src/webpki/deny.toml
```