### PR TITLE
Take aws-lc-rs 1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.7"
+version = "0.102.8"
 dependencies = [
  "aws-lc-rs",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
+checksum = "2f95446d919226d587817a7d21379e6eb099b97b45110a7f272a444ca5c54070"
 dependencies = [
  "aws-lc-sys",
  "mirai-annotations",
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e89b6941c2d1a7045538884d6e760ccfffdf8e1ffc2613d8efa74305e1f3752"
+checksum = "5055edc4a9a1b2a917a818258cdfb86a535947feebd9981adc99667a062c6f85"
 dependencies = [
  "bindgen",
  "cc",
@@ -103,12 +103,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -653,17 +654,3 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.102.7"
+version = "0.102.8"
 
 include = [
     "Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ ring = ["dep:ring"]
 std = ["alloc", "pki-types/std"]
 
 [dependencies]
-aws-lc-rs = { version = "1.8.1", optional = true, default-features = false, features = ["aws-lc-sys"] }
+aws-lc-rs = { version = "1.9", optional = true, default-features = false, features = ["aws-lc-sys"] }
 pki-types = { package = "rustls-pki-types", version = "1.7", default-features = false }
 ring = { version = "0.17", default-features = false, optional = true }
 untrusted = "0.9"

--- a/src/alg_tests.rs
+++ b/src/alg_tests.rs
@@ -357,6 +357,11 @@ test_verify_signed_data!(
     "ours/ecdsa-prime256v1-sha256-compressed.pem",
     OK_IF_POINT_COMPRESSION_SUPPORTED
 );
+test_verify_signed_data!(
+    test_ecdsa_prime256v1_sha256_spki_inside_spki,
+    "ours/ecdsa-prime256v1-sha256-spki-inside-spki.pem",
+    Err(Error::InvalidSignatureForPublicKey)
+);
 
 struct TestSignedData {
     spki: Vec<u8>,

--- a/src/alg_tests.rs
+++ b/src/alg_tests.rs
@@ -23,8 +23,9 @@ use crate::verify_cert::Budget;
 use crate::{der, signed_data};
 
 use super::{
-    INVALID_SIGNATURE_FOR_RSA_KEY, OK_IF_RSA_AVAILABLE, SUPPORTED_ALGORITHMS_IN_TESTS,
-    UNSUPPORTED_ECDSA_SHA512_SIGNATURE, UNSUPPORTED_SIGNATURE_ALGORITHM_FOR_RSA_KEY,
+    INVALID_SIGNATURE_FOR_RSA_KEY, OK_IF_POINT_COMPRESSION_SUPPORTED, OK_IF_RSA_AVAILABLE,
+    SUPPORTED_ALGORITHMS_IN_TESTS, UNSUPPORTED_ECDSA_SHA512_SIGNATURE,
+    UNSUPPORTED_SIGNATURE_ALGORITHM_FOR_RSA_KEY,
 };
 
 macro_rules! test_file_bytes {
@@ -344,6 +345,17 @@ test_verify_signed_data!(
     test_rsa2048_pkcs1_sha512,
     "rsa2048-pkcs1-sha512.pem",
     OK_IF_RSA_AVAILABLE
+);
+
+test_verify_signed_data!(
+    test_ecdsa_prime256v1_sha256,
+    "ours/ecdsa-prime256v1-sha256.pem",
+    Ok(())
+);
+test_verify_signed_data!(
+    test_ecdsa_prime256v1_sha256_compressed,
+    "ours/ecdsa-prime256v1-sha256-compressed.pem",
+    OK_IF_POINT_COMPRESSION_SUPPORTED
 );
 
 struct TestSignedData {

--- a/src/aws_lc_rs_algs.rs
+++ b/src/aws_lc_rs_algs.rs
@@ -207,6 +207,7 @@ mod tests {
     const INVALID_SIGNATURE_FOR_RSA_KEY: Error = Error::InvalidSignatureForPublicKey;
 
     const OK_IF_RSA_AVAILABLE: Result<(), Error> = Ok(());
+    const OK_IF_POINT_COMPRESSION_SUPPORTED: Result<(), Error> = Ok(());
 
     #[path = "alg_tests.rs"]
     mod alg_tests;

--- a/src/ring_algs.rs
+++ b/src/ring_algs.rs
@@ -198,6 +198,9 @@ mod tests {
         Err(Error::UnsupportedSignatureAlgorithm)
     };
 
+    const OK_IF_POINT_COMPRESSION_SUPPORTED: Result<(), Error> =
+        Err(Error::InvalidSignatureForPublicKey);
+
     #[path = "alg_tests.rs"]
     mod alg_tests;
 }

--- a/third-party/chromium/data/verify_signed_data/ours/ecdsa-prime256v1-sha256-compressed.pem
+++ b/third-party/chromium/data/verify_signed_data/ours/ecdsa-prime256v1-sha256-compressed.pem
@@ -1,0 +1,37 @@
+Copy of the uncompressed version, but with the public key compressed manually
+using `openssl ec`.
+
+
+$ openssl asn1parse -i < [PUBLIC KEY]
+    0:d=0  hl=2 l=  57 cons: SEQUENCE          
+    2:d=1  hl=2 l=  19 cons:  SEQUENCE          
+    4:d=2  hl=2 l=   7 prim:   OBJECT            :id-ecPublicKey
+   13:d=2  hl=2 l=   8 prim:   OBJECT            :prime256v1
+   23:d=1  hl=2 l=  34 prim:  BIT STRING        
+
+-----BEGIN PUBLIC KEY-----
+MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgADBKrsc2NXJvIT+4qeZNo7hjLkFJWpRNAEW1IuunJ
+A+tU=
+-----END PUBLIC KEY-----
+
+
+$ openssl asn1parse -i < [ALGORITHM]
+    0:d=0  hl=2 l=  10 cons: SEQUENCE          
+    2:d=1  hl=2 l=   8 prim:  OBJECT            :ecdsa-with-SHA256
+
+-----BEGIN ALGORITHM-----
+MAoGCCqGSM49BAMC
+-----END ALGORITHM-----
+
+-----BEGIN DATA-----
+MTIzNDAw
+-----END DATA-----
+
+
+$ openssl asn1parse -i < [SIGNATURE]
+    0:d=0  hl=2 l=  73 prim: BIT STRING        
+
+-----BEGIN SIGNATURE-----
+A0kAMEYCIQCo6hUMuAEl1zgcTB8dqOneJxH5kXBgQGpz15BFGeUTiAIhAPOrn6aL1HlzpzstQEg
+MK6UMIsnXbsIXJXKIKTKFRJuG
+-----END SIGNATURE-----

--- a/third-party/chromium/data/verify_signed_data/ours/ecdsa-prime256v1-sha256-spki-inside-spki.pem
+++ b/third-party/chromium/data/verify_signed_data/ours/ecdsa-prime256v1-sha256-spki-inside-spki.pem
@@ -1,0 +1,36 @@
+This is a copy of ecdsa-prime256v1-sha256.pem, but
+with the SPKI BIT STRING being the SPKI again.
+
+
+$ openssl asn1parse -i < [PUBLIC KEY]
+    0:d=0  hl=2 l= 115 cons: SEQUENCE          
+    2:d=1  hl=2 l=  19 cons:  SEQUENCE          
+    4:d=2  hl=2 l=   7 prim:   OBJECT            :id-ecPublicKey
+   13:d=2  hl=2 l=   8 prim:   OBJECT            :prime256v1
+   23:d=1  hl=2 l=  92 prim:  BIT STRING        
+
+-----BEGIN PUBLIC KEY-----
+MHMwEwYHKoZIzj0CAQYIKoZIzj0DAQcDXAAwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQEqux
+zY1cm8hP7ip5k2juGMuQUlalE0ARbUi66ckD61YfZMVeYqqOlugF3V4fO0F6q97Tgn8gdbRqlRu
+g2XVJd
+-----END PUBLIC KEY-----
+
+$ openssl asn1parse -i < [ALGORITHM]
+    0:d=0  hl=2 l=  10 cons: SEQUENCE          
+    2:d=1  hl=2 l=   8 prim:  OBJECT            :ecdsa-with-SHA256
+
+-----BEGIN ALGORITHM-----
+MAoGCCqGSM49BAMC
+-----END ALGORITHM-----
+
+-----BEGIN DATA-----
+MTIzNDAw
+-----END DATA-----
+
+$ openssl asn1parse -i < [SIGNATURE]
+    0:d=0  hl=2 l=  73 prim: BIT STRING        
+
+-----BEGIN SIGNATURE-----
+A0kAMEYCIQCo6hUMuAEl1zgcTB8dqOneJxH5kXBgQGpz15BFGeUTiAIhAPOrn6aL1HlzpzstQEg
+MK6UMIsnXbsIXJXKIKTKFRJuG
+-----END SIGNATURE-----

--- a/third-party/chromium/data/verify_signed_data/ours/ecdsa-prime256v1-sha256.pem
+++ b/third-party/chromium/data/verify_signed_data/ours/ecdsa-prime256v1-sha256.pem
@@ -1,0 +1,38 @@
+The key, message, and signature come from wycheproof ecdsa_secp256r1_sha256_test.json
+
+The signature was wrapped in an additional BITSTRING.
+
+
+$ openssl asn1parse -i < [PUBLIC KEY]
+    0:d=0  hl=2 l=  89 cons: SEQUENCE          
+    2:d=1  hl=2 l=  19 cons:  SEQUENCE          
+    4:d=2  hl=2 l=   7 prim:   OBJECT            :id-ecPublicKey
+   13:d=2  hl=2 l=   8 prim:   OBJECT            :prime256v1
+   23:d=1  hl=2 l=  66 prim:  BIT STRING        
+
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWpRNAEW1IuunJ
+A+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==
+-----END PUBLIC KEY-----
+
+
+$ openssl asn1parse -i < [ALGORITHM]
+    0:d=0  hl=2 l=  10 cons: SEQUENCE          
+    2:d=1  hl=2 l=   8 prim:  OBJECT            :ecdsa-with-SHA256
+
+-----BEGIN ALGORITHM-----
+MAoGCCqGSM49BAMC
+-----END ALGORITHM-----
+
+-----BEGIN DATA-----
+MTIzNDAw
+-----END DATA-----
+
+
+$ openssl asn1parse -i < [SIGNATURE]
+    0:d=0  hl=2 l=  73 prim: BIT STRING        
+
+-----BEGIN SIGNATURE-----
+A0kAMEYCIQCo6hUMuAEl1zgcTB8dqOneJxH5kXBgQGpz15BFGeUTiAIhAPOrn6aL1HlzpzstQEg
+MK6UMIsnXbsIXJXKIKTKFRJuG
+-----END SIGNATURE-----


### PR DESCRIPTION
Proposed release notes:

- **Support for aws-lc-rs 1.9 added**. This release adds supports for compressed EC public keys, when used with aws-lc-rs.

(nb. I plan to enable the `prebuilt-nasm` feature at the rustls level, not here. Mainly because this crate has a slower release cadence and it seems like a good idea to make that decision as high in the stack as possible.)