### PR TITLE
aws-lc-rs prebuilt-nasm, update cargo check external types nightly version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-05-01
+          toolchain: nightly-2024-06-30
           # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
 
       - run: cargo install --locked cargo-check-external-types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,10 +215,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust_channel }}
 
-      - name: Install NASM for aws-lc-rs on Windows
-        if: runner.os == 'Windows'
-        uses: ilammy/setup-nasm@v1
-
       - name: Install ninja-build tool for aws-lc-fips-sys on Windows
         if: runner.os == 'Windows'
         uses: seanmiddleditch/gha-setup-ninja@v5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ ring = ["dep:ring"]
 std = ["alloc", "pki-types/std"]
 
 [dependencies]
-aws-lc-rs = { version = "1.9", optional = true, default-features = false, features = ["aws-lc-sys"] }
+aws-lc-rs = { version = "1.9", optional = true, default-features = false, features = ["aws-lc-sys", "prebuilt-nasm"] }
 pki-types = { package = "rustls-pki-types", version = "1.7", default-features = false }
 ring = { version = "0.17", default-features = false, optional = true }
 untrusted = "0.9"


### PR DESCRIPTION
## Cargo: activate aws-lc-rs prebuilt-nasm feature

Upstream Rustls has done this since [0.23.13](https://github.com/rustls/rustls/releases/tag/v/0.23.13). This [prebuilt-nasm feature](https://github.com/aws/aws-lc-rs/blob/main/aws-lc-rs/README.md#prebuilt-nasm) makes aws-lc-rs more like Ring w.r.t to its ASM artifacts on Windows and allows removing the NASM install in CI.

## ci: adjust nightly for cargo-check-external-types

See the upstream [v0.1.13](https://github.com/awslabs/cargo-check-external-types/releases/tag/v0.1.13) release notes.