### PR TITLE
proj: fix clippy 1.83 findings

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -152,7 +152,9 @@ fn bench_search_borrowed_crl_small(c: &mut Bencher) {
         .unwrap()
         .into();
 
-    c.iter(|| black_box(assert!(matches!(crl.find_serial(FAKE_SERIAL), Ok(None)))));
+    c.iter(|| {
+        assert!(matches!(black_box(crl.find_serial(FAKE_SERIAL)), Ok(None)));
+    });
 }
 
 /// Benchmark searching a small CRL file in owned representation for a serial that does not
@@ -163,7 +165,9 @@ fn bench_search_owned_crl_small(c: &mut Bencher) {
         .unwrap()
         .into();
 
-    c.iter(|| black_box(assert!(matches!(crl.find_serial(FAKE_SERIAL), Ok(None)))));
+    c.iter(|| {
+        assert!(matches!(black_box(crl.find_serial(FAKE_SERIAL)), Ok(None)));
+    });
 }
 
 /// Benchmark searching a medium CRL file in borrowed representation for a serial that does not
@@ -174,7 +178,9 @@ fn bench_search_borrowed_crl_medium(c: &mut Bencher) {
         .unwrap()
         .into();
 
-    c.iter(|| black_box(assert!(matches!(crl.find_serial(FAKE_SERIAL), Ok(None)))));
+    c.iter(|| {
+        assert!(matches!(black_box(crl.find_serial(FAKE_SERIAL)), Ok(None)));
+    });
 }
 
 /// Benchmark searching a medium CRL file in owned representation for a serial that does not
@@ -185,7 +191,9 @@ fn bench_search_owned_crl_medium(c: &mut Bencher) {
         .unwrap()
         .into();
 
-    c.iter(|| black_box(assert!(matches!(crl.find_serial(FAKE_SERIAL), Ok(None)))));
+    c.iter(|| {
+        assert!(matches!(black_box(crl.find_serial(FAKE_SERIAL)), Ok(None)));
+    });
 }
 
 /// Benchmark searching a large CRL file in borrowed representation for a serial that does not
@@ -196,7 +204,9 @@ fn bench_search_borrowed_crl_large(c: &mut Bencher) {
         .unwrap()
         .into();
 
-    c.iter(|| black_box(assert!(matches!(crl.find_serial(FAKE_SERIAL), Ok(None)))));
+    c.iter(|| {
+        assert!(matches!(black_box(crl.find_serial(FAKE_SERIAL)), Ok(None)));
+    });
 }
 
 /// Benchmark searching a large CRL file in owned representation for a serial that does not
@@ -207,7 +217,9 @@ fn bench_search_owned_crl_large(c: &mut Bencher) {
         .unwrap()
         .into();
 
-    c.iter(|| black_box(assert!(matches!(crl.find_serial(FAKE_SERIAL), Ok(None)))));
+    c.iter(|| {
+        assert!(matches!(black_box(crl.find_serial(FAKE_SERIAL)), Ok(None)));
+    });
 }
 
 benchmark_group!(

--- a/src/crl/mod.rs
+++ b/src/crl/mod.rs
@@ -110,7 +110,7 @@ pub struct RevocationOptions<'a> {
     pub(crate) expiration_policy: ExpirationPolicy,
 }
 
-impl<'a> RevocationOptions<'a> {
+impl RevocationOptions<'_> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn check(
         &self,

--- a/src/crl/types.rs
+++ b/src/crl/types.rs
@@ -43,7 +43,7 @@ impl<'a> From<BorrowedCertRevocationList<'a>> for CertRevocationList<'a> {
     }
 }
 
-impl<'a> CertRevocationList<'a> {
+impl CertRevocationList<'_> {
     /// Return the DER encoded issuer of the CRL.
     pub fn issuer(&self) -> &[u8] {
         match self {

--- a/src/der.rs
+++ b/src/der.rs
@@ -344,7 +344,7 @@ pub(crate) struct BitStringFlags<'a> {
     raw_bits: &'a [u8],
 }
 
-impl<'a> BitStringFlags<'a> {
+impl BitStringFlags<'_> {
     pub(crate) fn bit_set(&self, bit: usize) -> bool {
         let byte_index = bit / 8;
         let bit_shift = 7 - (bit % 8);
@@ -587,7 +587,7 @@ mod tests {
     }
 
     fn bytes_reader(bytes: &[u8]) -> untrusted::Reader<'_> {
-        return untrusted::Reader::new(untrusted::Input::from(bytes));
+        untrusted::Reader::new(untrusted::Input::from(bytes))
     }
 
     #[test]

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -72,7 +72,7 @@ impl<'a> TryFrom<&'a CertificateDer<'a>> for EndEntityCert<'a> {
     }
 }
 
-impl<'a> EndEntityCert<'a> {
+impl EndEntityCert<'_> {
     /// Verifies that the end-entity certificate is valid for use against the
     /// specified Extended Key Usage (EKU).
     ///

--- a/src/rpk_entity.rs
+++ b/src/rpk_entity.rs
@@ -29,7 +29,7 @@ impl<'a> TryFrom<&'a SubjectPublicKeyInfoDer<'a>> for RawPublicKeyEntity<'a> {
     }
 }
 
-impl<'a> RawPublicKeyEntity<'a> {
+impl RawPublicKeyEntity<'_> {
     /// Verifies the signature `signature` of message `msg` using a raw public key,
     /// supporting RFC 7250.
     ///

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -235,7 +235,7 @@ impl<'a> Iterator for IntermediateIterator<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for IntermediateIterator<'a> {
+impl DoubleEndedIterator for IntermediateIterator<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         match self.intermediates.split_last() {
             Some((head, tail)) => {

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -22,7 +22,7 @@ pub(crate) struct Extension<'a> {
     pub(crate) value: untrusted::Input<'a>,
 }
 
-impl<'a> Extension<'a> {
+impl Extension<'_> {
     pub(crate) fn unsupported(&self) -> Result<(), Error> {
         match self.critical {
             true => Err(Error::UnsupportedCriticalExtension),


### PR DESCRIPTION
Applies `clippy --fix` to remove findings [presently breaking the `clippy` task](https://github.com/rustls/webpki/actions/runs/12073854466/job/33670784016) as of 1.83 being released.
