### PR TITLE
ci: use persist-credentials: false in testgen.yml

### DIFF
--- a/.github/workflows/testgen.yml
+++ b/.github/workflows/testgen.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python environment
         uses: actions/setup-python@v5
@@ -47,6 +49,8 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
We were consistent about doing this in the main CI workflow, but not the testgen workflow. This [is flagged](https://woodruffw.github.io/zizmor/audits/#artipacked) when running Zizmor 0.7.0 on the repo's CI config. As mentioned in the description of this finding:

> By default, using [actions/checkout](https://github.com/actions/checkout) causes a credential to be persisted in the checked-out repo's .git/config, so that subsequent git operations can be authenticated.
>
> Subsequent steps may accidentally publicly persist .git/config, e.g. by including it in a publicly accessible artifact via [actions/upload-artifact](https://github.com/actions/upload-artifact).
>
> However, even without this, persisting the credential in the .git/config is non-ideal unless actually needed.

We don't need it, so turn it off consistently :-)