### PR TITLE
Add context in name validation errors

### DIFF
--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -20,7 +20,7 @@ use pki_types::{
 
 use crate::crl::RevocationOptions;
 use crate::error::Error;
-use crate::subject_name::{verify_dns_names, verify_ip_address_names, NameIterator};
+use crate::subject_name::{verify_dns_names, verify_ip_address_names};
 use crate::verify_cert::{self, KeyUsage, VerifiedPath};
 use crate::{cert, signed_data};
 
@@ -125,16 +125,10 @@ impl EndEntityCert<'_> {
         server_name: &ServerName<'_>,
     ) -> Result<(), Error> {
         match server_name {
-            ServerName::DnsName(dns_name) => verify_dns_names(
-                dns_name,
-                NameIterator::new(Some(self.inner.subject), self.inner.subject_alt_name),
-            ),
+            ServerName::DnsName(dns_name) => verify_dns_names(dns_name, &self.inner),
             // IP addresses are not compared against the subject field;
             // only against Subject Alternative Names.
-            ServerName::IpAddress(ip_address) => verify_ip_address_names(
-                ip_address,
-                NameIterator::new(None, self.inner.subject_alt_name),
-            ),
+            ServerName::IpAddress(ip_address) => verify_ip_address_names(ip_address, &self.inner),
             _ => Err(Error::UnsupportedNameType),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 /// An error that occurs during certificate validation or name validation.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// The encoding of some ASN.1 DER-encoded item is invalid.

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,8 +12,15 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 use core::fmt;
 use core::ops::ControlFlow;
+
+#[cfg(feature = "alloc")]
+use pki_types::ServerName;
 
 /// An error that occurs during certificate validation or name validation.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -33,7 +40,7 @@ pub enum Error {
     CertExpired,
 
     /// The certificate is not valid for the name it is being validated for.
-    CertNotValidForName,
+    CertNotValidForName(InvalidNameContext),
 
     /// The certificate is not valid yet; i.e. the time it is being validated
     /// for is earlier than the certificate's notBefore time.
@@ -216,7 +223,7 @@ impl Error {
         match &self {
             // Errors related to certificate validity
             Self::CertNotValidYet | Self::CertExpired => 290,
-            Self::CertNotValidForName => 280,
+            Self::CertNotValidForName(_) => 280,
             Self::CertRevoked | Self::UnknownRevocationStatus | Self::CrlExpired => 270,
             Self::InvalidCrlSignatureForPublicKey | Self::InvalidSignatureForPublicKey => 260,
             Self::SignatureAlgorithmMismatch => 250,
@@ -299,6 +306,22 @@ impl fmt::Display for Error {
 
 #[cfg(feature = "std")]
 impl ::std::error::Error for Error {}
+
+/// Additional context for the `CertNotValidForName` error variant.
+///
+/// The contents of this type depend on whether the `alloc` feature is enabled.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidNameContext {
+    /// Expected server name.
+    #[cfg(feature = "alloc")]
+    pub expected: ServerName<'static>,
+    /// The names presented in the end entity certificate.
+    ///
+    /// These are the subject names as present in the leaf certificate and may contain DNS names
+    /// with or without a wildcard label as well as IP address names.
+    #[cfg(feature = "alloc")]
+    pub presented: Vec<String>,
+}
 
 /// Trailing data was found while parsing DER-encoded input for the named type.
 #[allow(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub use {
         UnknownStatusPolicy,
     },
     end_entity::EndEntityCert,
-    error::{DerTypeId, Error},
+    error::{DerTypeId, Error, InvalidNameContext},
     rpk_entity::RawPublicKeyEntity,
     signed_data::alg_id,
     trust_anchor::anchor_from_trusted_cert,

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -17,14 +17,11 @@ use core::fmt::Write;
 use pki_types::{DnsName, InvalidDnsNameError};
 
 use super::verify::{GeneralName, NameIterator};
-use crate::Error;
+use crate::{Cert, Error};
 
-pub(crate) fn verify_dns_names(
-    reference: &DnsName<'_>,
-    mut names: NameIterator<'_>,
-) -> Result<(), Error> {
+pub(crate) fn verify_dns_names(reference: &DnsName<'_>, cert: &Cert<'_>) -> Result<(), Error> {
     let dns_name = untrusted::Input::from(reference.as_ref().as_bytes());
-    names
+    NameIterator::new(Some(cert.subject), cert.subject_alt_name)
         .find_map(|result| {
             let name = match result {
                 Ok(name) => name,

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -868,14 +868,14 @@ mod tests {
 
     #[test]
     fn presented_matches_reference_test() {
-        for &(presented, reference, expected_result) in PRESENTED_MATCHES_REFERENCE {
+        for (presented, reference, expected_result) in PRESENTED_MATCHES_REFERENCE {
             let actual_result = presented_id_matches_reference_id(
                 untrusted::Input::from(presented),
                 IdRole::Reference,
                 untrusted::Input::from(reference),
             );
             assert_eq!(
-                actual_result, expected_result,
+                &actual_result, expected_result,
                 "presented_id_matches_reference_id(\"{:?}\", \"{:?}\")",
                 presented, reference
             );
@@ -945,14 +945,14 @@ mod tests {
 
     #[test]
     fn presented_matches_constraint_test() {
-        for &(presented, constraint, expected_result) in PRESENTED_MATCHES_CONSTRAINT {
+        for (presented, constraint, expected_result) in PRESENTED_MATCHES_CONSTRAINT {
             let actual_result = presented_id_matches_reference_id(
                 untrusted::Input::from(presented),
                 IdRole::NameConstraint,
                 untrusted::Input::from(constraint),
             );
             assert_eq!(
-                actual_result, expected_result,
+                &actual_result, expected_result,
                 "presented_id_matches_constraint(\"{:?}\", \"{:?}\")",
                 presented, constraint,
             );

--- a/src/subject_name/ip_address.rs
+++ b/src/subject_name/ip_address.rs
@@ -15,18 +15,15 @@
 use pki_types::IpAddr;
 
 use super::verify::{GeneralName, NameIterator};
-use crate::Error;
+use crate::{Cert, Error};
 
-pub(crate) fn verify_ip_address_names(
-    reference: &IpAddr,
-    mut names: NameIterator<'_>,
-) -> Result<(), Error> {
+pub(crate) fn verify_ip_address_names(reference: &IpAddr, cert: &Cert<'_>) -> Result<(), Error> {
     let ip_address = match reference {
         IpAddr::V4(ip) => untrusted::Input::from(ip.as_ref()),
         IpAddr::V6(ip) => untrusted::Input::from(ip.as_ref()),
     };
 
-    names
+    NameIterator::new(None, cert.subject_alt_name)
         .find_map(|result| {
             let name = match result {
                 Ok(name) => name,

--- a/src/subject_name/ip_address.rs
+++ b/src/subject_name/ip_address.rs
@@ -659,7 +659,7 @@ mod alloc_tests {
         use std::boxed::Box;
         use std::net::IpAddr;
 
-        for &(presented, constraint_address, constraint_mask, expected_result) in
+        for (presented, constraint_address, constraint_mask, expected_result) in
             PRESENTED_MATCHES_CONSTRAINT
         {
             let presented_bytes: Box<[u8]> = match presented.parse::<IpAddr>().unwrap() {
@@ -680,7 +680,7 @@ mod alloc_tests {
                 untrusted::Input::from(&constraint_bytes),
             );
             assert_eq!(
-                actual_result, expected_result,
+                &actual_result, expected_result,
                 "presented_id_matches_constraint(\"{:?}\", \"{:?}\")",
                 presented_bytes, constraint_bytes
             );

--- a/tests/custom_ekus.rs
+++ b/tests/custom_ekus.rs
@@ -43,7 +43,7 @@ pub fn verify_custom_eku_mdoc() {
 
     let eku_mdoc = KeyUsage::required(&[40, 129, 140, 93, 5, 1, 2]);
     check_cert(ee, ca, eku_mdoc, time, Ok(()));
-    check_cert(ee, ca, KeyUsage::server_auth(), time, err);
+    check_cert(ee, ca, KeyUsage::server_auth(), time, err.clone());
     check_cert(ee, ca, eku_mdoc, time, Ok(()));
     check_cert(ee, ca, KeyUsage::server_auth(), time, err);
 }


### PR DESCRIPTION
This pretty much achieves my goals and is probably workable but not quite pretty:

- No `Copy` for `Error` means a semver-incompatible change
  * Semver-incompatible changes in webpki specifically are relatively manageable since most users don't depend on it directly
- A little strange to get different errors for `alloc` vs no `alloc`?

I can fix test failures etc if we think this is worth doing.