### PR TITLE
add aws-lc-rs-fips feature, adjust sys dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,4 +357,8 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
 
       - name: Check feature powerset
-        run: cargo hack check --feature-powerset --no-dev-deps
+        run: >
+          cargo hack check
+          --feature-powerset
+          --no-dev-deps
+          --mutually-exclusive-features aws-lc-rs,aws-lc-rs-fips

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           - --features=alloc
           - --all-features
           - --no-default-features
-          - --no-default-features --features alloc,std,aws_lc_rs
+          - --no-default-features --features alloc,std,aws-lc-rs
 
         mode:
           - # debug
@@ -127,7 +127,7 @@ jobs:
           - features: --features=alloc
           - features: --no-default-features
           - features: --no-default-features --features alloc,std
-          - features: --no-default-features --features alloc,std,aws_lc_rs
+          - features: --no-default-features --features alloc,std,aws-lc-rs
           - features: --all-features
             mode: --release
           - features: --all-features
@@ -189,17 +189,17 @@ jobs:
             host_os: ubuntu-latest
 
           # check aws-lc-rs alone
-          - features: --no-default-features --features alloc,std,aws_lc_rs
+          - features: --no-default-features --features alloc,std,aws-lc-rs
             mode: # debug
             rust_channel: stable
             host_os: macos-latest
 
-          - features: --no-default-features --features alloc,std,aws_lc_rs
+          - features: --no-default-features --features alloc,std,aws-lc-rs
             mode: # debug
             rust_channel: stable
             host_os: windows-latest
 
-          - features: --no-default-features --features alloc,std,aws_lc_rs
+          - features: --no-default-features --features alloc,std,aws-lc-rs
             mode: # debug
             rust_channel: stable
             host_os: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,11 +12,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-fips-sys"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59057b878509d88952425fe694a2806e468612bde2d71943f3cd8034935b5032"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+ "regex",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
 dependencies = [
+ "aws-lc-fips-sys",
  "aws-lc-sys",
  "paste",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.0"
 dependencies = [
  "aws-lc-rs",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,12 +75,13 @@ name = "webpki"
 [features]
 default = ["std", "ring"]
 alloc = ["ring?/alloc", "pki-types/alloc"]
-aws-lc-rs = ["dep:aws-lc-rs"]
+aws-lc-rs = ["dep:aws-lc-rs", "aws-lc-rs/aws-lc-sys", "aws-lc-rs/prebuilt-nasm"]
+aws-lc-rs-fips = ["dep:aws-lc-rs", "aws-lc-rs/fips"]
 ring = ["dep:ring"]
 std = ["alloc", "pki-types/std"]
 
 [dependencies]
-aws-lc-rs = { version = "1.9", optional = true, default-features = false, features = ["aws-lc-sys", "prebuilt-nasm"] }
+aws-lc-rs = { version = "1.9", optional = true, default-features = false }
 pki-types = { package = "rustls-pki-types", version = "1.7", default-features = false }
 ring = { version = "0.17", default-features = false, optional = true }
 untrusted = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ name = "webpki"
 [features]
 default = ["std", "ring"]
 alloc = ["ring?/alloc", "pki-types/alloc"]
-aws_lc_rs = ["dep:aws-lc-rs"]
+aws-lc-rs = ["dep:aws-lc-rs"]
 ring = ["dep:ring"]
 std = ["alloc", "pki-types/std"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.102.8"
+version = "0.103.0"
 
 include = [
     "Cargo.toml",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! | `alloc` | Enable features that require use of the heap. Currently all RSA signature algorithms require this feature. |
 //! | `std` | Enable features that require libstd. Implies `alloc`. |
 //! | `ring` | Enable use of the *ring* crate for cryptography. |
-//! | `aws_lc_rs` | Enable use of the aws-lc-rs crate for cryptography. |
+//! | `aws-lc-rs` | Enable use of the aws-lc-rs crate for cryptography. Previously this feature was named `aws_lc_rs`. |
 
 #![no_std]
 #![warn(elided_lifetimes_in_paths, unreachable_pub, clippy::use_self)]
@@ -51,7 +51,7 @@ extern crate alloc;
 #[macro_use]
 mod der;
 
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(feature = "aws-lc-rs")]
 mod aws_lc_rs_algs;
 mod cert;
 mod end_entity;
@@ -107,7 +107,7 @@ pub mod ring {
     };
 }
 
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(feature = "aws-lc-rs")]
 /// Signature verification algorithm implementations using the aws-lc-rs crypto library.
 pub mod aws_lc_rs {
     pub use super::aws_lc_rs_algs::{
@@ -121,7 +121,7 @@ pub mod aws_lc_rs {
 
 /// An array of all the verification algorithms exported by this crate.
 ///
-/// This will be empty if the crate is built without the `ring` and `aws_lc_rs` features.
+/// This will be empty if the crate is built without the `ring` and `aws-lc-rs` features.
 pub static ALL_VERIFICATION_ALGS: &[&dyn types::SignatureVerificationAlgorithm] = &[
     #[cfg(feature = "ring")]
     ring::ECDSA_P256_SHA256,
@@ -147,35 +147,35 @@ pub static ALL_VERIFICATION_ALGS: &[&dyn types::SignatureVerificationAlgorithm] 
     ring::RSA_PSS_2048_8192_SHA384_LEGACY_KEY,
     #[cfg(all(feature = "ring", feature = "alloc"))]
     ring::RSA_PSS_2048_8192_SHA512_LEGACY_KEY,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::ECDSA_P256_SHA256,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::ECDSA_P256_SHA384,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::ECDSA_P384_SHA256,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::ECDSA_P384_SHA384,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::ECDSA_P521_SHA256,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::ECDSA_P521_SHA384,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::ECDSA_P521_SHA512,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::ED25519,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::RSA_PKCS1_2048_8192_SHA256,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::RSA_PKCS1_2048_8192_SHA384,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::RSA_PKCS1_2048_8192_SHA512,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::RSA_PKCS1_3072_8192_SHA384,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::RSA_PSS_2048_8192_SHA256_LEGACY_KEY,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::RSA_PSS_2048_8192_SHA384_LEGACY_KEY,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     aws_lc_rs::RSA_PSS_2048_8192_SHA512_LEGACY_KEY,
 ];
 

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -695,7 +695,7 @@ pub(crate) enum Role {
     EndEntity,
 }
 
-#[cfg(all(test, feature = "alloc", any(feature = "ring", feature = "aws_lc_rs")))]
+#[cfg(all(test, feature = "alloc", any(feature = "ring", feature = "aws-lc-rs")))]
 mod tests {
     use super::*;
     use crate::test_utils;

--- a/tests/better_tls.rs
+++ b/tests/better_tls.rs
@@ -1,4 +1,4 @@
-#![cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#![cfg(any(feature = "ring", feature = "aws-lc-rs"))]
 
 use core::time::Duration;
 use std::collections::HashMap;
@@ -16,7 +16,7 @@ use webpki::{anchor_from_trusted_cert, KeyUsage};
 static ALGS: &[&dyn SignatureVerificationAlgorithm] = &[
     #[cfg(feature = "ring")]
     webpki::ring::ECDSA_P256_SHA256,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     webpki::aws_lc_rs::ECDSA_P256_SHA256,
 ];
 

--- a/tests/client_auth.rs
+++ b/tests/client_auth.rs
@@ -12,7 +12,7 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![cfg(all(feature = "alloc", any(feature = "ring", feature = "aws_lc_rs")))]
+#![cfg(all(feature = "alloc", any(feature = "ring", feature = "aws-lc-rs")))]
 
 use core::time::Duration;
 use pki_types::{CertificateDer, UnixTime};

--- a/tests/client_auth_revocation.rs
+++ b/tests/client_auth_revocation.rs
@@ -12,7 +12,7 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#![cfg(any(feature = "ring", feature = "aws-lc-rs"))]
 
 use core::time::Duration;
 
@@ -25,7 +25,7 @@ use webpki::{
 static ALGS: &[&dyn SignatureVerificationAlgorithm] = &[
     #[cfg(feature = "ring")]
     webpki::ring::ECDSA_P256_SHA256,
-    #[cfg(feature = "aws_lc_rs")]
+    #[cfg(feature = "aws-lc-rs")]
     webpki::aws_lc_rs::ECDSA_P256_SHA256,
 ];
 

--- a/tests/custom_ekus.rs
+++ b/tests/custom_ekus.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "alloc", any(feature = "ring", feature = "aws_lc_rs")))]
+#![cfg(all(feature = "alloc", any(feature = "ring", feature = "aws-lc-rs")))]
 
 use core::time::Duration;
 

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -561,9 +561,9 @@ def signatures(force: bool) -> None:
     }
 
     feature_gates = {
-        "ECDSA_P521_SHA256": 'all(not(feature = "ring"), feature = "aws_lc_rs")',
-        "ECDSA_P521_SHA384": 'all(not(feature = "ring"), feature = "aws_lc_rs")',
-        "ECDSA_P521_SHA512": 'all(not(feature = "ring"), feature = "aws_lc_rs")',
+        "ECDSA_P521_SHA256": 'all(not(feature = "ring"), feature = "aws-lc-rs")',
+        "ECDSA_P521_SHA384": 'all(not(feature = "ring"), feature = "aws-lc-rs")',
+        "ECDSA_P521_SHA512": 'all(not(feature = "ring"), feature = "aws-lc-rs")',
     }
 
     rsa_types: list[str] = [

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,7 +12,7 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#![cfg(any(feature = "ring", feature = "aws-lc-rs"))]
 
 use core::time::Duration;
 

--- a/tests/signatures.rs
+++ b/tests/signatures.rs
@@ -12,7 +12,7 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#![cfg(any(feature = "ring", feature = "aws-lc-rs"))]
 
 use pki_types::{CertificateDer, SignatureVerificationAlgorithm};
 #[cfg(feature = "ring")]
@@ -26,7 +26,7 @@ use webpki::ring::{
     RSA_PSS_2048_8192_SHA384_LEGACY_KEY, RSA_PSS_2048_8192_SHA512_LEGACY_KEY,
 };
 
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
 use webpki::aws_lc_rs::{
     ECDSA_P256_SHA256, ECDSA_P256_SHA384, ECDSA_P384_SHA256, ECDSA_P384_SHA384, ECDSA_P521_SHA256,
     ECDSA_P521_SHA384, ECDSA_P521_SHA512, ED25519, RSA_PKCS1_2048_8192_SHA256,
@@ -112,11 +112,11 @@ fn ed25519_key_and_ed25519_detects_bad_signature_rpk() {
 fn ed25519_key_rejected_by_other_algorithms() {
     let ee = include_bytes!("signatures/ed25519.ee.der");
     for algorithm in &[
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA256,
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA384,
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA512,
         ECDSA_P256_SHA256,
         ECDSA_P256_SHA384,
@@ -244,11 +244,11 @@ fn ecdsa_p256_key_and_ecdsa_p256_sha256_detects_bad_signature_rpk() {
 fn ecdsa_p256_key_rejected_by_other_algorithms() {
     let ee = include_bytes!("signatures/ecdsa_p256.ee.der");
     for algorithm in &[
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA256,
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA384,
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA512,
         ECDSA_P384_SHA256,
         ECDSA_P384_SHA384,
@@ -375,11 +375,11 @@ fn ecdsa_p384_key_and_ecdsa_p384_sha256_detects_bad_signature_rpk() {
 fn ecdsa_p384_key_rejected_by_other_algorithms() {
     let ee = include_bytes!("signatures/ecdsa_p384.ee.der");
     for algorithm in &[
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA256,
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA384,
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA512,
         ECDSA_P256_SHA256,
         ECDSA_P256_SHA384,
@@ -400,7 +400,7 @@ fn ecdsa_p384_key_rejected_by_other_algorithms() {
 }
 
 #[test]
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
 fn ecdsa_p521_key_and_ecdsa_p521_sha512_good_signature() {
     let ee = include_bytes!("signatures/ecdsa_p521.ee.der");
     let message = include_bytes!("signatures/message.bin");
@@ -410,7 +410,7 @@ fn ecdsa_p521_key_and_ecdsa_p521_sha512_good_signature() {
 }
 
 #[test]
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
 fn ecdsa_p521_key_and_ecdsa_p521_sha512_good_signature_rpk() {
     let rpk = include_bytes!("signatures/ecdsa_p521.spki.der");
     let message = include_bytes!("signatures/message.bin");
@@ -423,7 +423,7 @@ fn ecdsa_p521_key_and_ecdsa_p521_sha512_good_signature_rpk() {
 }
 
 #[test]
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
 fn ecdsa_p521_key_and_ecdsa_p521_sha512_detects_bad_signature() {
     let ee = include_bytes!("signatures/ecdsa_p521.ee.der");
     let message = include_bytes!("signatures/message.bin");
@@ -437,7 +437,7 @@ fn ecdsa_p521_key_and_ecdsa_p521_sha512_detects_bad_signature() {
 }
 
 #[test]
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
 fn ecdsa_p521_key_and_ecdsa_p521_sha512_detects_bad_signature_rpk() {
     let rpk = include_bytes!("signatures/ecdsa_p521.spki.der");
     let message = include_bytes!("signatures/message.bin");
@@ -451,7 +451,7 @@ fn ecdsa_p521_key_and_ecdsa_p521_sha512_detects_bad_signature_rpk() {
 }
 
 #[test]
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
 fn ecdsa_p521_key_and_ecdsa_p521_sha256_good_signature() {
     let ee = include_bytes!("signatures/ecdsa_p521.ee.der");
     let message = include_bytes!("signatures/message.bin");
@@ -461,7 +461,7 @@ fn ecdsa_p521_key_and_ecdsa_p521_sha256_good_signature() {
 }
 
 #[test]
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
 fn ecdsa_p521_key_and_ecdsa_p521_sha256_good_signature_rpk() {
     let rpk = include_bytes!("signatures/ecdsa_p521.spki.der");
     let message = include_bytes!("signatures/message.bin");
@@ -474,7 +474,7 @@ fn ecdsa_p521_key_and_ecdsa_p521_sha256_good_signature_rpk() {
 }
 
 #[test]
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
 fn ecdsa_p521_key_and_ecdsa_p521_sha256_detects_bad_signature() {
     let ee = include_bytes!("signatures/ecdsa_p521.ee.der");
     let message = include_bytes!("signatures/message.bin");
@@ -488,7 +488,7 @@ fn ecdsa_p521_key_and_ecdsa_p521_sha256_detects_bad_signature() {
 }
 
 #[test]
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
 fn ecdsa_p521_key_and_ecdsa_p521_sha256_detects_bad_signature_rpk() {
     let rpk = include_bytes!("signatures/ecdsa_p521.spki.der");
     let message = include_bytes!("signatures/message.bin");
@@ -502,7 +502,7 @@ fn ecdsa_p521_key_and_ecdsa_p521_sha256_detects_bad_signature_rpk() {
 }
 
 #[test]
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
 fn ecdsa_p521_key_and_ecdsa_p521_sha384_good_signature() {
     let ee = include_bytes!("signatures/ecdsa_p521.ee.der");
     let message = include_bytes!("signatures/message.bin");
@@ -512,7 +512,7 @@ fn ecdsa_p521_key_and_ecdsa_p521_sha384_good_signature() {
 }
 
 #[test]
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
 fn ecdsa_p521_key_and_ecdsa_p521_sha384_good_signature_rpk() {
     let rpk = include_bytes!("signatures/ecdsa_p521.spki.der");
     let message = include_bytes!("signatures/message.bin");
@@ -525,7 +525,7 @@ fn ecdsa_p521_key_and_ecdsa_p521_sha384_good_signature_rpk() {
 }
 
 #[test]
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
 fn ecdsa_p521_key_and_ecdsa_p521_sha384_detects_bad_signature() {
     let ee = include_bytes!("signatures/ecdsa_p521.ee.der");
     let message = include_bytes!("signatures/message.bin");
@@ -539,7 +539,7 @@ fn ecdsa_p521_key_and_ecdsa_p521_sha384_detects_bad_signature() {
 }
 
 #[test]
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
 fn ecdsa_p521_key_and_ecdsa_p521_sha384_detects_bad_signature_rpk() {
     let rpk = include_bytes!("signatures/ecdsa_p521.spki.der");
     let message = include_bytes!("signatures/message.bin");
@@ -906,11 +906,11 @@ fn rsa_2048_key_and_rsa_pss_2048_8192_sha512_legacy_key_detects_bad_signature_rp
 fn rsa_2048_key_rejected_by_other_algorithms() {
     let ee = include_bytes!("signatures/rsa_2048.ee.der");
     for algorithm in &[
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA256,
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA384,
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA512,
         ECDSA_P256_SHA256,
         ECDSA_P256_SHA384,
@@ -1310,11 +1310,11 @@ fn rsa_3072_key_and_rsa_pkcs1_3072_8192_sha384_detects_bad_signature_rpk() {
 fn rsa_3072_key_rejected_by_other_algorithms() {
     let ee = include_bytes!("signatures/rsa_3072.ee.der");
     for algorithm in &[
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA256,
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA384,
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA512,
         ECDSA_P256_SHA256,
         ECDSA_P256_SHA384,
@@ -1714,11 +1714,11 @@ fn rsa_4096_key_and_rsa_pkcs1_3072_8192_sha384_detects_bad_signature_rpk() {
 fn rsa_4096_key_rejected_by_other_algorithms() {
     let ee = include_bytes!("signatures/rsa_4096.ee.der");
     for algorithm in &[
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA256,
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA384,
-        #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+        #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
         ECDSA_P521_SHA512,
         ECDSA_P256_SHA256,
         ECDSA_P256_SHA384,

--- a/tests/tls_server_certs.rs
+++ b/tests/tls_server_certs.rs
@@ -11,7 +11,7 @@
 // WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-#![cfg(all(feature = "alloc", any(feature = "ring", feature = "aws_lc_rs")))]
+#![cfg(all(feature = "alloc", any(feature = "ring", feature = "aws-lc-rs")))]
 
 use core::time::Duration;
 


### PR DESCRIPTION
Previously we unconditionally used the `aws-lc-sys` and `prebuilt-nasm` features of the `aws-lc-rs` dep, meaning we always brought along `aws-lc-sys` (note the `prebuilt-nasm` feature customizes that dep).

However, when a user is looking for a FIPS crypto provider we want to avoid bringing in `aws-lc-sys` and instead use `aws-lc-rs/fips` to get `aws-lc-fips-sys`.

This commit makes the `aws-lc-rs` feature of `webpki` activate the "usual" config: `aws-lc-rs/aws-lc-sys` w/ `aws-lc-rs/prebuilt-nasm` to have `aws-lc-sys` with prebuilt assmebly to avoid the nasm dep.

A new `aws-lc-rs-fips` feature is added for `webpki` that activates the FIPS specific config: `aws-lc-rs/fips`. The `aws-lc-sys` and `prebuilt-nasm` features are **not** activated.

Updates https://github.com/rustls/webpki/issues/307 