### PR TITLE
Run all tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
         uses: seanmiddleditch/gha-setup-ninja@v6
 
       - name: cargo test (${{ matrix.mode }}, ${{ matrix.features }})
-        run: cargo test --locked ${{ matrix.features }} ${{ matrix.mode }} -- --ignored
+        run: cargo test --locked ${{ matrix.features }} ${{ matrix.mode }} -- --include-ignored
         env:
           RUSTFLAGS: "-D warnings"
           AWS_LC_SYS_PREBUILT_NASM: "1" # for benefit of rcgen

--- a/tests/better_tls.rs
+++ b/tests/better_tls.rs
@@ -21,7 +21,7 @@ static ALGS: &[&dyn SignatureVerificationAlgorithm] = &[
     webpki::aws_lc_rs::ECDSA_P256_SHA256,
 ];
 
-#[ignore] // Runs slower than other unit tests - opt-in with `cargo test -- --ignored`
+#[ignore] // Runs slower than other unit tests - opt-in with `cargo test -- --include-ignored`
 #[test]
 fn path_building() {
     let better_tls = testdata();
@@ -40,7 +40,7 @@ fn path_building() {
     );
 }
 
-#[ignore] // Runs slower than other unit tests - opt-in with `cargo test -- --ignored`
+#[ignore] // Runs slower than other unit tests - opt-in with `cargo test -- --include-ignored`
 #[test]
 fn name_constraints() {
     let better_tls = testdata();


### PR DESCRIPTION
`cargo test -- --ignored` runs only ignored tests, so we've been omitting other tests in CI for a while.