### PR TITLE
Cargo: ring 0.17.8 -> 0.17.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.5"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -412,15 +412,14 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -510,12 +509,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "syn"

--- a/deny.toml
+++ b/deny.toml
@@ -5,18 +5,10 @@ yanked = "deny"
 allow = [
     "Apache-2.0",
     "ISC",
-    "LicenseRef-ring",
     "LicenseRef-webpki",
     "MIT",
 ]
 confidence-threshold = 1.0
-
-[[licenses.clarify]]
-name = "ring"
-expression = "LicenseRef-ring"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 },
-]
 
 # XXX: Figure out how to deal with the Google-source test data
 # https://github.com/briansmith/webpki/issues/148.

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,10 @@
 [advisories]
 yanked = "deny"
+ignore = [
+  # paste (via aws-lc-rs) is unmaintained
+  # https://github.com/aws/aws-lc-rs/issues/722
+  "RUSTSEC-2024-0436" 
+]
 
 [licenses]
 allow = [


### PR DESCRIPTION
Updating ring v0.17.8 -> v0.17.13

Also a few small `cargo deny` fixes:

* deny: remove LicenseRef-ring: This license is no longer being encountered by `cargo deny` after `*ring*` 0.17.10 incorporated the upstream BoringSSL relicense work.
* deny: ignore [RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436) - we'll follow the upstream progress on this one.


