### PR TITLE
avoid inference hazard usize comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.0"
+version = "0.103.1"
 dependencies = [
  "aws-lc-rs",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.103.0"
+version = "0.103.1"
 
 include = [
     "Cargo.toml",

--- a/src/der.rs
+++ b/src/der.rs
@@ -222,7 +222,7 @@ pub(crate) fn read_tag_and_get_value_limited<'a>(
 pub(crate) fn asn1_wrap(tag: Tag, bytes: &[u8]) -> Vec<u8> {
     let len = bytes.len();
     // The length is encoded differently depending on how many bytes there are
-    if len < SHORT_FORM_LEN_MAX.into() {
+    if len < usize::from(SHORT_FORM_LEN_MAX) {
         // Short form: the length is encoded using a single byte
         // Contents: Tag byte, single length byte, and passed bytes
         let mut ret = Vec::with_capacity(2 + len);


### PR DESCRIPTION
## Proposed release notes:

* Avoid a possible type inference error when building in projects that also use `jhpratt/deranged`.

Resolves https://github.com/rustls/webpki/issues/333