### PR TITLE
Remove tests from package that is published

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,6 @@ include = [
     "src/x509.rs",
     "src/verify_cert.rs",
     "src/lib.rs",
-
-    "tests/**",
 ]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Hi everyone 👋

While reviewing dependency updates in our project (trying to assure supply chain safety) I noticed that the `tests` directory contains many binary files and a couple of scripts as well. That makes it harder to review when checking the supply chain and I was wondering if it would be possible to remove this directory from the published package. That would remove a potential vector for a security vulnerability in the future.

The downside of course would be that the tests couldn't be run from the crate package anymore, but I'm not sure how popular that is.

Best regards!