### PR TITLE
Bump version to 0.103.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 dependencies = [
  "aws-lc-rs",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.103.3"
+version = "0.103.4"
 
 include = [
     "Cargo.toml",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,10 @@ pub use {
         UnknownStatusPolicy,
     },
     end_entity::EndEntityCert,
-    error::{DerTypeId, Error, InvalidNameContext},
+    error::{
+        DerTypeId, Error, InvalidNameContext, UnsupportedSignatureAlgorithmContext,
+        UnsupportedSignatureAlgorithmForPublicKeyContext,
+    },
     rpk_entity::RawPublicKeyEntity,
     trust_anchor::anchor_from_trusted_cert,
     verify_cert::{KeyUsage, RequiredEkuNotFoundContext, VerifiedPath},


### PR DESCRIPTION
Draft state to prevent merging before downstream is ready -- please review.

## Proposed release notes

* Add unstable support for the post-quantum ML-DSA signature algorithms when using aws-lc-rs. Enable the `aws-lc-rs-unstable` feature to expose these algorithms (only works when `aws-lc-rs-fips` is not enabled).
* Use new `UnsupportedSignatureAlgorithmContext`, `UnsupportedCrlSignatureAlgorithmContext`, `UnsupportedSignatureAlgorithmForPublicKeyContext` and `UnsupportedCrlSignatureAlgorithmForPublicKeyContext` error variants which contain additional context about the error condition. The related contextless variants have been deprecated.