### PR TITLE
Declare ML-DSA as not FIPS approved in the API

### DIFF
--- a/src/aws_lc_rs_algs.rs
+++ b/src/aws_lc_rs_algs.rs
@@ -12,6 +12,7 @@ struct AwsLcRsAlgorithm {
     public_key_alg_id: AlgorithmIdentifier,
     signature_alg_id: AlgorithmIdentifier,
     verification_alg: &'static dyn signature::VerificationAlgorithm,
+    in_fips_submission: bool,
 }
 
 impl SignatureVerificationAlgorithm for AwsLcRsAlgorithm {
@@ -52,7 +53,7 @@ impl SignatureVerificationAlgorithm for AwsLcRsAlgorithm {
     }
 
     fn fips(&self) -> bool {
-        try_fips_mode().is_ok()
+        self.in_fips_submission && try_fips_mode().is_ok()
     }
 }
 
@@ -62,6 +63,8 @@ pub static ML_DSA_44: &dyn SignatureVerificationAlgorithm = &AwsLcRsAlgorithm {
     public_key_alg_id: alg_id::ML_DSA_44,
     signature_alg_id: alg_id::ML_DSA_44,
     verification_alg: &unstable::signature::MLDSA_44,
+    // Not included in AWS-LC-FIPS 3.0 FIPS scope
+    in_fips_submission: false,
 };
 
 /// ML-DSA signatures using the [6, 5] matrix (security strength category 3).
@@ -70,6 +73,8 @@ pub static ML_DSA_65: &dyn SignatureVerificationAlgorithm = &AwsLcRsAlgorithm {
     public_key_alg_id: alg_id::ML_DSA_65,
     signature_alg_id: alg_id::ML_DSA_65,
     verification_alg: &unstable::signature::MLDSA_65,
+    // Not included in AWS-LC-FIPS 3.0 FIPS scope
+    in_fips_submission: false,
 };
 
 /// ML-DSA signatures using the [8. 7] matrix (security strength category 5).
@@ -78,6 +83,8 @@ pub static ML_DSA_87: &dyn SignatureVerificationAlgorithm = &AwsLcRsAlgorithm {
     public_key_alg_id: alg_id::ML_DSA_87,
     signature_alg_id: alg_id::ML_DSA_87,
     verification_alg: &unstable::signature::MLDSA_87,
+    // Not included in AWS-LC-FIPS 3.0 FIPS scope
+    in_fips_submission: false,
 };
 
 /// ECDSA signatures using the P-256 curve and SHA-256.
@@ -85,6 +92,7 @@ pub static ECDSA_P256_SHA256: &dyn SignatureVerificationAlgorithm = &AwsLcRsAlgo
     public_key_alg_id: alg_id::ECDSA_P256,
     signature_alg_id: alg_id::ECDSA_SHA256,
     verification_alg: &signature::ECDSA_P256_SHA256_ASN1,
+    in_fips_submission: true,
 };
 
 /// ECDSA signatures using the P-256 curve and SHA-384. Deprecated.
@@ -92,6 +100,7 @@ pub static ECDSA_P256_SHA384: &dyn SignatureVerificationAlgorithm = &AwsLcRsAlgo
     public_key_alg_id: alg_id::ECDSA_P256,
     signature_alg_id: alg_id::ECDSA_SHA384,
     verification_alg: &signature::ECDSA_P256_SHA384_ASN1,
+    in_fips_submission: true,
 };
 
 /// ECDSA signatures using the P-384 curve and SHA-256. Deprecated.
@@ -99,6 +108,7 @@ pub static ECDSA_P384_SHA256: &dyn SignatureVerificationAlgorithm = &AwsLcRsAlgo
     public_key_alg_id: alg_id::ECDSA_P384,
     signature_alg_id: alg_id::ECDSA_SHA256,
     verification_alg: &signature::ECDSA_P384_SHA256_ASN1,
+    in_fips_submission: true,
 };
 
 /// ECDSA signatures using the P-384 curve and SHA-384.
@@ -106,6 +116,7 @@ pub static ECDSA_P384_SHA384: &dyn SignatureVerificationAlgorithm = &AwsLcRsAlgo
     public_key_alg_id: alg_id::ECDSA_P384,
     signature_alg_id: alg_id::ECDSA_SHA384,
     verification_alg: &signature::ECDSA_P384_SHA384_ASN1,
+    in_fips_submission: true,
 };
 
 /// ECDSA signatures using the P-521 curve and SHA-256.
@@ -113,6 +124,7 @@ pub static ECDSA_P521_SHA256: &dyn SignatureVerificationAlgorithm = &AwsLcRsAlgo
     public_key_alg_id: alg_id::ECDSA_P521,
     signature_alg_id: alg_id::ECDSA_SHA256,
     verification_alg: &signature::ECDSA_P521_SHA256_ASN1,
+    in_fips_submission: true,
 };
 
 /// ECDSA signatures using the P-521 curve and SHA-384.
@@ -120,6 +132,7 @@ pub static ECDSA_P521_SHA384: &dyn SignatureVerificationAlgorithm = &AwsLcRsAlgo
     public_key_alg_id: alg_id::ECDSA_P521,
     signature_alg_id: alg_id::ECDSA_SHA384,
     verification_alg: &signature::ECDSA_P521_SHA384_ASN1,
+    in_fips_submission: true,
 };
 
 /// ECDSA signatures using the P-521 curve and SHA-512.
@@ -127,6 +140,7 @@ pub static ECDSA_P521_SHA512: &dyn SignatureVerificationAlgorithm = &AwsLcRsAlgo
     public_key_alg_id: alg_id::ECDSA_P521,
     signature_alg_id: alg_id::ECDSA_SHA512,
     verification_alg: &signature::ECDSA_P521_SHA512_ASN1,
+    in_fips_submission: true,
 };
 
 /// RSA PKCS#1 1.5 signatures using SHA-256 for keys of 2048-8192 bits.
@@ -134,6 +148,7 @@ pub static RSA_PKCS1_2048_8192_SHA256: &dyn SignatureVerificationAlgorithm = &Aw
     public_key_alg_id: alg_id::RSA_ENCRYPTION,
     signature_alg_id: alg_id::RSA_PKCS1_SHA256,
     verification_alg: &signature::RSA_PKCS1_2048_8192_SHA256,
+    in_fips_submission: true,
 };
 
 /// RSA PKCS#1 1.5 signatures using SHA-384 for keys of 2048-8192 bits.
@@ -141,6 +156,7 @@ pub static RSA_PKCS1_2048_8192_SHA384: &dyn SignatureVerificationAlgorithm = &Aw
     public_key_alg_id: alg_id::RSA_ENCRYPTION,
     signature_alg_id: alg_id::RSA_PKCS1_SHA384,
     verification_alg: &signature::RSA_PKCS1_2048_8192_SHA384,
+    in_fips_submission: true,
 };
 
 /// RSA PKCS#1 1.5 signatures using SHA-512 for keys of 2048-8192 bits.
@@ -148,6 +164,7 @@ pub static RSA_PKCS1_2048_8192_SHA512: &dyn SignatureVerificationAlgorithm = &Aw
     public_key_alg_id: alg_id::RSA_ENCRYPTION,
     signature_alg_id: alg_id::RSA_PKCS1_SHA512,
     verification_alg: &signature::RSA_PKCS1_2048_8192_SHA512,
+    in_fips_submission: true,
 };
 
 /// RSA PKCS#1 1.5 signatures using SHA-256 for keys of 2048-8192 bits,
@@ -168,6 +185,7 @@ pub static RSA_PKCS1_2048_8192_SHA256_ABSENT_PARAMS: &dyn SignatureVerificationA
             "data/alg-rsa-pkcs1-sha256-absent-params.der"
         )),
         verification_alg: &signature::RSA_PKCS1_2048_8192_SHA256,
+        in_fips_submission: true,
     };
 
 /// RSA PKCS#1 1.5 signatures using SHA-384 for keys of 2048-8192 bits,
@@ -188,6 +206,7 @@ pub static RSA_PKCS1_2048_8192_SHA384_ABSENT_PARAMS: &dyn SignatureVerificationA
             "data/alg-rsa-pkcs1-sha384-absent-params.der"
         )),
         verification_alg: &signature::RSA_PKCS1_2048_8192_SHA384,
+        in_fips_submission: true,
     };
 
 /// RSA PKCS#1 1.5 signatures using SHA-512 for keys of 2048-8192 bits,
@@ -208,6 +227,7 @@ pub static RSA_PKCS1_2048_8192_SHA512_ABSENT_PARAMS: &dyn SignatureVerificationA
             "data/alg-rsa-pkcs1-sha512-absent-params.der"
         )),
         verification_alg: &signature::RSA_PKCS1_2048_8192_SHA512,
+        in_fips_submission: true,
     };
 
 /// RSA PKCS#1 1.5 signatures using SHA-384 for keys of 3072-8192 bits.
@@ -215,6 +235,7 @@ pub static RSA_PKCS1_3072_8192_SHA384: &dyn SignatureVerificationAlgorithm = &Aw
     public_key_alg_id: alg_id::RSA_ENCRYPTION,
     signature_alg_id: alg_id::RSA_PKCS1_SHA384,
     verification_alg: &signature::RSA_PKCS1_3072_8192_SHA384,
+    in_fips_submission: true,
 };
 
 /// RSA PSS signatures using SHA-256 for keys of 2048-8192 bits and of
@@ -226,6 +247,7 @@ pub static RSA_PSS_2048_8192_SHA256_LEGACY_KEY: &dyn SignatureVerificationAlgori
         public_key_alg_id: alg_id::RSA_ENCRYPTION,
         signature_alg_id: alg_id::RSA_PSS_SHA256,
         verification_alg: &signature::RSA_PSS_2048_8192_SHA256,
+        in_fips_submission: true,
     };
 
 /// RSA PSS signatures using SHA-384 for keys of 2048-8192 bits and of
@@ -237,6 +259,7 @@ pub static RSA_PSS_2048_8192_SHA384_LEGACY_KEY: &dyn SignatureVerificationAlgori
         public_key_alg_id: alg_id::RSA_ENCRYPTION,
         signature_alg_id: alg_id::RSA_PSS_SHA384,
         verification_alg: &signature::RSA_PSS_2048_8192_SHA384,
+        in_fips_submission: true,
     };
 
 /// RSA PSS signatures using SHA-512 for keys of 2048-8192 bits and of
@@ -248,6 +271,7 @@ pub static RSA_PSS_2048_8192_SHA512_LEGACY_KEY: &dyn SignatureVerificationAlgori
         public_key_alg_id: alg_id::RSA_ENCRYPTION,
         signature_alg_id: alg_id::RSA_PSS_SHA512,
         verification_alg: &signature::RSA_PSS_2048_8192_SHA512,
+        in_fips_submission: true,
     };
 
 /// ED25519 signatures according to RFC 8410
@@ -255,6 +279,7 @@ pub static ED25519: &dyn SignatureVerificationAlgorithm = &AwsLcRsAlgorithm {
     public_key_alg_id: alg_id::ED25519,
     signature_alg_id: alg_id::ED25519,
     verification_alg: &signature::ED25519,
+    in_fips_submission: true,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
Sorry, should have caught this in review. ML-DSA is not included in the latest draft submission (https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/policydocs/DRAFT-140-3-AmazonSecurityPolicy-3.0.0-dynamic.pdf) so shouldn't return `true` from `fips()` here irrespective of the underlying FIPS mode.