### PR TITLE
Export more types to enable ExtendedKeyUsageValidator implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,10 @@ pub use {
     },
     rpk_entity::RawPublicKeyEntity,
     trust_anchor::anchor_from_trusted_cert,
-    verify_cert::{ExtendedKeyUsageValidator, KeyUsage, RequiredEkuNotFoundContext, VerifiedPath},
+    verify_cert::{
+        ExtendedKeyUsageValidator, KeyPurposeId, KeyPurposeIdIter, KeyUsage,
+        RequiredEkuNotFoundContext, VerifiedPath,
+    },
 };
 
 #[cfg(feature = "alloc")]

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -617,6 +617,7 @@ impl ExtendedKeyUsage {
     }
 }
 
+/// Iterator over [`KeyPurposeId`]s, for use in [`ExtendedKeyUsageValidator`].
 pub struct KeyPurposeIdIter<'a, 'r> {
     input: &'r mut untrusted::Reader<'a>,
 }


### PR DESCRIPTION
Fixes #380.

cc @sgrams