### PR TITLE
Ignore wildcard labels when matching name constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.104.0-alpha.5"
+version = "0.104.0-alpha.6"
 dependencies = [
  "base64",
  "bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "ISC"
 name = "rustls-webpki"
 readme = "README.md"
 repository = "https://github.com/rustls/webpki"
-version = "0.104.0-alpha.5"
+version = "0.104.0-alpha.6"
 
 include = [
     "Cargo.toml",

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -319,8 +319,7 @@ pub(super) fn presented_id_matches_reference_id(
     //
     // For excluded subtrees: we still expand the wildcard so that a SAN whose expansions could
     // reach into an excluded subtree is rejected (see CVE-2025-61727).
-    if presented.peek(b'*')
-        && reference_dns_id_role != IdRole::NameConstraint(Subtrees::PermittedSubtrees)
+    if presented.peek(b'*') && reference_dns_id_role != IdRole::NameConstraint(Subtrees::Permitted)
     {
         if presented.skip(1).is_err() {
             unreachable!();
@@ -980,7 +979,7 @@ mod tests {
         for (presented, constraint, expected_result) in PRESENTED_MATCHES_CONSTRAINT {
             let actual_result = presented_id_matches_reference_id(
                 untrusted::Input::from(presented),
-                IdRole::NameConstraint(Subtrees::PermittedSubtrees),
+                IdRole::NameConstraint(Subtrees::Permitted),
                 untrusted::Input::from(constraint),
             );
             assert_eq!(
@@ -995,7 +994,7 @@ mod tests {
         for (presented, constraint, expected_result) in WILDCARD_CONSTRAINT_CONTAINMENT {
             let actual_result = presented_id_matches_reference_id(
                 untrusted::Input::from(presented),
-                IdRole::NameConstraint(Subtrees::PermittedSubtrees),
+                IdRole::NameConstraint(Subtrees::Permitted),
                 untrusted::Input::from(constraint),
             );
             assert_eq!(
@@ -1032,7 +1031,7 @@ mod tests {
         for (presented, constraint, expected_result) in WILDCARD_EXCLUDED_INTERSECTION {
             let actual_result = presented_id_matches_reference_id(
                 untrusted::Input::from(presented),
-                IdRole::NameConstraint(Subtrees::ExcludedSubtrees),
+                IdRole::NameConstraint(Subtrees::Excluded),
                 untrusted::Input::from(constraint),
             );
             assert_eq!(

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -23,6 +23,7 @@ use pki_types::{DnsName, InvalidDnsNameError};
 use super::{GeneralName, NameIterator};
 use crate::cert::Cert;
 use crate::error::{Error, InvalidNameContext};
+use crate::subject_name::Subtrees;
 
 pub(crate) fn verify_dns_names(reference: &DnsName<'_>, cert: &Cert<'_>) -> Result<(), Error> {
     let dns_name = untrusted::Input::from(reference.as_ref().as_bytes());
@@ -245,7 +246,7 @@ pub(super) fn presented_id_matches_reference_id(
 
     if !is_valid_dns_id(reference_dns_id, reference_dns_id_role, Wildcards::Deny) {
         return Err(match reference_dns_id_role {
-            IdRole::NameConstraint => Error::MalformedNameConstraint,
+            IdRole::NameConstraint(_) => Error::MalformedNameConstraint,
             _ => Error::MalformedDnsIdentifier,
         });
     }
@@ -256,7 +257,7 @@ pub(super) fn presented_id_matches_reference_id(
     match reference_dns_id_role {
         IdRole::Reference => (),
 
-        IdRole::NameConstraint if presented_dns_id.len() > reference_dns_id.len() => {
+        IdRole::NameConstraint(_) if presented_dns_id.len() > reference_dns_id.len() => {
             if reference_dns_id.is_empty() {
                 // An empty constraint matches everything.
                 return Ok(true);
@@ -305,13 +306,22 @@ pub(super) fn presented_id_matches_reference_id(
             }
         }
 
-        IdRole::NameConstraint => (),
+        IdRole::NameConstraint(_) => (),
 
         IdRole::Presented => unreachable!(),
     }
 
     // Only allow wildcard labels that consist only of '*'.
-    if presented.peek(b'*') {
+    //
+    // For permitted subtrees: ignore the wildcard label entirely; a wildcard SAN like
+    // `*.example.com` can expand to names (like `evil.example.com`) that fall outside the
+    // permitted subtree, so we must not treat it as contained.
+    //
+    // For excluded subtrees: we still expand the wildcard so that a SAN whose expansions could
+    // reach into an excluded subtree is rejected (see CVE-2025-61727).
+    if presented.peek(b'*')
+        && reference_dns_id_role != IdRole::NameConstraint(Subtrees::PermittedSubtrees)
+    {
         if presented.skip(1).is_err() {
             unreachable!();
         }
@@ -346,7 +356,7 @@ pub(super) fn presented_id_matches_reference_id(
     // Allow a relative presented DNS ID to match an absolute reference DNS ID,
     // unless we're matching a name constraint.
     if !reference.at_end() {
-        if reference_dns_id_role != IdRole::NameConstraint {
+        if !matches!(reference_dns_id_role, IdRole::NameConstraint(_)) {
             match reference.read_byte() {
                 Ok(b'.') => (),
                 _ => {
@@ -383,7 +393,7 @@ enum Wildcards {
 pub(super) enum IdRole {
     Reference,
     Presented,
-    NameConstraint,
+    NameConstraint(Subtrees),
 }
 
 // https://tools.ietf.org/html/rfc5280#section-4.2.1.6:
@@ -408,7 +418,7 @@ fn is_valid_dns_id(
 
     let mut input = untrusted::Reader::new(hostname);
 
-    if id_role == IdRole::NameConstraint && input.at_end() {
+    if matches!(id_role, IdRole::NameConstraint(_)) && input.at_end() {
         return true;
     }
 
@@ -467,7 +477,8 @@ fn is_valid_dns_id(
 
             Ok(b'.') => {
                 dot_count += 1;
-                if label_length == 0 && (id_role != IdRole::NameConstraint || !is_first_byte) {
+                let name_constrained = matches!(id_role, IdRole::NameConstraint(_));
+                if label_length == 0 && (!name_constrained || !is_first_byte) {
                     return false;
                 }
                 if label_ends_with_hyphen {
@@ -951,8 +962,10 @@ mod tests {
         // Presented IDs with wildcard
         (b"*.example.com", b".example.com", Ok(true)),
         (b"*.example.com", b"example.com", Ok(true)),
-        (b"*.example.com", b"www.example.com", Ok(true)),
-        (b"*.example.com", b"www.EXAMPLE.COM", Ok(true)),
+        // `*.example.com` expands to names like `evil.example.com` that are
+        // outside the subtree `www.example.com`, so it is not contained.
+        (b"*.example.com", b"www.example.com", Ok(false)),
+        (b"*.example.com", b"www.EXAMPLE.COM", Ok(false)),
         (b"*.example.com", b"www.axample.com", Ok(false)),
         (b"*.example.com", b".xample.com", Ok(false)),
         (b"*.example.com", b"xample.com", Ok(false)),
@@ -967,7 +980,7 @@ mod tests {
         for (presented, constraint, expected_result) in PRESENTED_MATCHES_CONSTRAINT {
             let actual_result = presented_id_matches_reference_id(
                 untrusted::Input::from(presented),
-                IdRole::NameConstraint,
+                IdRole::NameConstraint(Subtrees::PermittedSubtrees),
                 untrusted::Input::from(constraint),
             );
             assert_eq!(
@@ -976,4 +989,72 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn wildcard_san_not_contained_in_constraint() {
+        for (presented, constraint, expected_result) in WILDCARD_CONSTRAINT_CONTAINMENT {
+            let actual_result = presented_id_matches_reference_id(
+                untrusted::Input::from(presented),
+                IdRole::NameConstraint(Subtrees::PermittedSubtrees),
+                untrusted::Input::from(constraint),
+            );
+            assert_eq!(
+                &actual_result, expected_result,
+                "presented_id_matches_constraint(\"{presented:?}\", \"{constraint:?}\")",
+            );
+        }
+    }
+
+    // Per RFC 5280 4.2.1.10, a permitted dNSName subtree `www.example.com`
+    // covers only names formed by prepending labels to `www.example.com`.
+    // A wildcard SAN `*.example.com` can expand to e.g. `evil.example.com`,
+    // which is outside that subtree, so it must not be considered contained.
+    // In contrast, `*.www.example.com` only expands to names inside the
+    // subtree and is correctly accepted.
+    #[expect(clippy::type_complexity)]
+    const WILDCARD_CONSTRAINT_CONTAINMENT: &[(&[u8], &[u8], Result<bool, Error>)] = &[
+        // Bug: `*.example.com` is broader than the permitted subtree
+        // `www.example.com` and must not satisfy the constraint.
+        (b"*.example.com", b"www.example.com", Ok(false)),
+        // Control: `*.www.example.com` stays within the subtree.
+        (b"*.www.example.com", b"www.example.com", Ok(true)),
+        // Further out-of-subtree wildcard SANs that must be rejected.
+        (b"*.example.com", b"a.b.example.com", Ok(false)),
+        (b"*.b.example.com", b"a.b.example.com", Ok(false)),
+    ];
+
+    // For excluded subtrees, a wildcard SAN must be treated as matching if
+    // any of its expansions could fall inside the excluded subtree
+    // (CVE-2025-61727). This is the opposite polarity from the containment
+    // test used for permitted subtrees.
+    #[test]
+    fn wildcard_san_could_match_excluded_subtree() {
+        for (presented, constraint, expected_result) in WILDCARD_EXCLUDED_INTERSECTION {
+            let actual_result = presented_id_matches_reference_id(
+                untrusted::Input::from(presented),
+                IdRole::NameConstraint(Subtrees::ExcludedSubtrees),
+                untrusted::Input::from(constraint),
+            );
+            assert_eq!(
+                &actual_result, expected_result,
+                "presented_id_matches_constraint(\"{presented:?}\", \"{constraint:?}\")",
+            );
+        }
+    }
+
+    #[expect(clippy::type_complexity)]
+    const WILDCARD_EXCLUDED_INTERSECTION: &[(&[u8], &[u8], Result<bool, Error>)] = &[
+        // All expansions of `*.example.com` fall under the excluded subtree.
+        (b"*.example.com", b"example.com", Ok(true)),
+        (b"*.example.com", b".example.com", Ok(true)),
+        // `*.example.com` can expand to `www.example.com`, which is inside
+        // the excluded subtree rooted at `www.example.com`.
+        (b"*.example.com", b"www.example.com", Ok(true)),
+        (b"*.example.com", b"www.EXAMPLE.COM", Ok(true)),
+        // The wildcard cannot reach two labels deep, so it does not
+        // intersect a more specific excluded subtree.
+        (b"*.example.com", b"a.b.example.com", Ok(false)),
+        // Disjoint parent labels never intersect.
+        (b"*.example.com", b"www.other.com", Ok(false)),
+    ];
 }

--- a/src/subject_name/mod.rs
+++ b/src/subject_name/mod.rs
@@ -127,7 +127,11 @@ fn check_presented_id_conforms_to_constraints(
 
             let matches = match (name, base) {
                 (GeneralName::DnsName(name), GeneralName::DnsName(base)) => {
-                    dns_name::presented_id_matches_reference_id(name, IdRole::NameConstraint, base)
+                    dns_name::presented_id_matches_reference_id(
+                        name,
+                        IdRole::NameConstraint(subtrees),
+                        base,
+                    )
                 }
 
                 (GeneralName::DirectoryName, GeneralName::DirectoryName) => Ok(
@@ -204,7 +208,7 @@ fn check_presented_id_conforms_to_constraints(
     None
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 enum Subtrees {
     PermittedSubtrees,
     ExcludedSubtrees,

--- a/src/subject_name/mod.rs
+++ b/src/subject_name/mod.rs
@@ -92,8 +92,8 @@ fn check_presented_id_conforms_to_constraints(
     budget: &mut Budget,
 ) -> Option<Result<(), Error>> {
     let subtrees = [
-        (Subtrees::PermittedSubtrees, permitted_subtrees),
-        (Subtrees::ExcludedSubtrees, excluded_subtrees),
+        (Subtrees::Permitted, permitted_subtrees),
+        (Subtrees::Excluded, excluded_subtrees),
     ];
 
     fn general_subtree<'b>(input: &mut untrusted::Reader<'b>) -> Result<GeneralName<'b>, Error> {
@@ -149,8 +149,8 @@ fn check_presented_id_conforms_to_constraints(
                     // Rejection is achieved by not matching any PermittedSubtrees, and matching all
                     // ExcludedSubtrees.
                     match subtrees {
-                        Subtrees::PermittedSubtrees => false,
-                        Subtrees::ExcludedSubtrees => true,
+                        Subtrees::Permitted => false,
+                        Subtrees::Excluded => true,
                     },
                 ),
 
@@ -180,19 +180,19 @@ fn check_presented_id_conforms_to_constraints(
             };
 
             match (subtrees, matches) {
-                (Subtrees::PermittedSubtrees, Ok(true)) => {
+                (Subtrees::Permitted, Ok(true)) => {
                     has_permitted_subtrees_match = true;
                 }
 
-                (Subtrees::PermittedSubtrees, Ok(false)) => {
+                (Subtrees::Permitted, Ok(false)) => {
                     has_permitted_subtrees_mismatch = true;
                 }
 
-                (Subtrees::ExcludedSubtrees, Ok(true)) => {
+                (Subtrees::Excluded, Ok(true)) => {
                     return Some(Err(Error::NameConstraintViolation));
                 }
 
-                (Subtrees::ExcludedSubtrees, Ok(false)) => (),
+                (Subtrees::Excluded, Ok(false)) => (),
                 (_, Err(err)) => return Some(Err(err)),
             }
         }
@@ -210,8 +210,8 @@ fn check_presented_id_conforms_to_constraints(
 
 #[derive(Clone, Copy, PartialEq)]
 enum Subtrees {
-    PermittedSubtrees,
-    ExcludedSubtrees,
+    Permitted,
+    Excluded,
 }
 
 pub(crate) struct NameIterator<'a> {

--- a/tests/tls_server_certs.rs
+++ b/tests/tls_server_certs.rs
@@ -338,6 +338,58 @@ fn wildcard_san_rejected_if_in_excluded_subtree() {
     );
 }
 
+/// CVE-2025-61727: a wildcard SAN like `*.example.com` can expand to a name (like
+/// `evil.example.com`) that falls inside an excluded subtree such as `evil.example.com`. Such
+/// certificates must be rejected even though the excluded subtree is narrower than the wildcard's
+/// parent label.
+#[test]
+fn wildcard_san_rejected_if_could_match_excluded_subtree() {
+    let issuer = make_issuer(Some(NameConstraints {
+        permitted_subtrees: vec![],
+        excluded_subtrees: vec![GeneralSubtree::DnsName("evil.example.com".to_string())],
+    }));
+    let ee = generate_cert(
+        vec![SanType::DnsName("*.example.com".try_into().unwrap())],
+        &issuer,
+    );
+    assert_eq!(
+        check_cert(
+            ee.der(),
+            issuer.der(),
+            &[],
+            &[],
+            &["DnsName(\"*.example.com\")"]
+        ),
+        Err(webpki::Error::NameConstraintViolation)
+    );
+}
+
+/// When a CA name constraint permits `www.example.com`, leaf certificates with a wildcard SAN of
+/// `*.example.com` should be rejected, because it could match names outside the permitted subtree.
+///
+/// <https://github.com/rustls/webpki/security/advisories/GHSA-xgp8-3hg3-c2mh>
+#[test]
+fn wildcard_san_rejected_if_could_match_name_outside_permitted_subtree() {
+    let issuer = make_issuer(Some(NameConstraints {
+        permitted_subtrees: vec![GeneralSubtree::DnsName("foo.example.com".to_string())],
+        excluded_subtrees: vec![],
+    }));
+    let ee = generate_cert(
+        vec![SanType::DnsName("*.example.com".try_into().unwrap())],
+        &issuer,
+    );
+    assert_eq!(
+        check_cert(
+            ee.der(),
+            issuer.der(),
+            &[],
+            &[],
+            &["DnsName(\"*.example.com\")"]
+        ),
+        Err(webpki::Error::NameConstraintViolation)
+    );
+}
+
 #[test]
 fn ip4_address_san_rejected_if_in_excluded_subtree() {
     let issuer = make_issuer(Some(NameConstraints {


### PR DESCRIPTION
Addresses an issue privately reported by @1seal, which we've decided to address in public.