### PR TITLE
Rewrite constraint matching to avoid permissive catch-all branch

### DIFF
--- a/src/subject_name/mod.rs
+++ b/src/subject_name/mod.rs
@@ -125,10 +125,12 @@ fn check_presented_id_conforms_to_constraints(
                 Err(err) => return Some(Err(err)),
             };
 
+            // Avoid having a catch-all branch here which might fail open on new variants
             let matches = match (name, base) {
                 (GeneralName::DnsName(name), GeneralName::DnsName(base)) => {
                     dns_name::presented_id_matches_reference_id(name, IdRole::NameConstraint, base)
                 }
+                (GeneralName::DnsName(_), _) => continue,
 
                 (GeneralName::DirectoryName, GeneralName::DirectoryName) => Ok(
                     // Reject any uses of directory name constraints; we don't implement this.
@@ -149,10 +151,19 @@ fn check_presented_id_conforms_to_constraints(
                         Subtrees::ExcludedSubtrees => true,
                     },
                 ),
+                (GeneralName::DirectoryName, _) => continue,
 
                 (GeneralName::IpAddress(name), GeneralName::IpAddress(base)) => {
                     ip_address::presented_id_matches_constraint(name, base)
                 }
+                (GeneralName::IpAddress(_), _) => continue,
+
+                // We currently don't support URI constraints -- fail closed for now.
+                (
+                    GeneralName::UniformResourceIdentifier(_),
+                    GeneralName::UniformResourceIdentifier(_),
+                ) => Ok(false),
+                (GeneralName::UniformResourceIdentifier(_), _) => continue,
 
                 // RFC 4280 says "If a name constraints extension that is marked as
                 // critical imposes constraints on a particular name form, and an
@@ -167,12 +178,7 @@ fn check_presented_id_conforms_to_constraints(
                 {
                     Err(Error::NameConstraintViolation)
                 }
-
-                _ => {
-                    // mismatch between constraint and name types; continue with current
-                    // name and next constraint
-                    continue;
-                }
+                (GeneralName::Unsupported(_), _) => continue,
             };
 
             match (subtrees, matches) {

--- a/tests/tls_server_certs.rs
+++ b/tests/tls_server_certs.rs
@@ -17,8 +17,9 @@ use core::time::Duration;
 
 use pki_types::{CertificateDer, ServerName, UnixTime};
 use rcgen::{
-    Certificate, CertificateParams, CertifiedIssuer, CidrSubnet, DistinguishedName, DnType,
-    GeneralSubtree, IsCa, KeyPair, NameConstraints, SanType, date_time_ymd,
+    Certificate, CertificateParams, CertifiedIssuer, CidrSubnet, CustomExtension,
+    DistinguishedName, DnType, GeneralSubtree, IsCa, KeyPair, NameConstraints, SanType,
+    date_time_ymd,
 };
 use webpki::{ExtendedKeyUsage, InvalidNameContext, anchor_from_trusted_cert};
 
@@ -558,6 +559,51 @@ fn ip46_mixed_address_san_allowed() {
         ),
         Ok(())
     );
+}
+
+/// Since we don't have real constraint matching implemented for URI names, fail closed.
+#[test]
+fn uri_san_rejected_against_uri_permitted_subtree() {
+    let ca_key = KeyPair::generate().unwrap();
+    let mut ca_params = issuer_params("issuer.example.com").unwrap();
+    ca_params
+        .custom_extensions
+        .push(uri_permitted_name_constraints(
+            b"https://allowed.example.com",
+        ));
+    let issuer = CertifiedIssuer::self_signed(ca_params, ca_key).expect("failed to generate CA");
+
+    let ee = generate_cert(
+        vec![SanType::URI("https://evil.example.com".try_into().unwrap())],
+        &issuer,
+    );
+    assert_eq!(
+        check_cert(ee.der(), issuer.der(), &[], &[], &[]),
+        Err(webpki::Error::NameConstraintViolation),
+    );
+}
+
+// Hand-encode a NameConstraints extension (OID 2.5.29.30) with a single
+// permittedSubtree containing a URI GeneralName. rcgen's GeneralSubtree enum
+// doesn't expose a URI variant, so we emit the DER directly.
+fn uri_permitted_name_constraints(uri: &[u8]) -> CustomExtension {
+    assert!(uri.len() < 128);
+    // URI GeneralName: [6] IMPLICIT IA5String
+    let mut uri_gn = vec![0x86, uri.len() as u8];
+    uri_gn.extend_from_slice(uri);
+    // GeneralSubtree SEQUENCE { base GeneralName, ... }
+    let mut subtree = vec![0x30, uri_gn.len() as u8];
+    subtree.extend_from_slice(&uri_gn);
+    // permittedSubtrees [0] IMPLICIT GeneralSubtrees
+    let mut permitted = vec![0xa0, subtree.len() as u8];
+    permitted.extend_from_slice(&subtree);
+    // NameConstraints SEQUENCE
+    let mut nc = vec![0x30, permitted.len() as u8];
+    nc.extend_from_slice(&permitted);
+
+    let mut ext = CustomExtension::from_oid_content(&[2, 5, 29, 30], nc);
+    ext.set_criticality(true);
+    ext
 }
 
 #[test]


### PR DESCRIPTION
Addresses an issue privately reported by @1seal, which we've decided to address in public.