### PR TITLE
tests: avoid vendored limbo.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,15 +104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bzip2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
-dependencies = [
- "libbz2-rs-sys",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,12 +323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libbz2-rs-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
-
-[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,7 +331,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "limbo-harness-support"
 version = "0.1.0"
-source = "git+https://github.com/C2SP/x509-limbo?rev=9c7359242f16265a5154bc5989eca91822ef5ed2#9c7359242f16265a5154bc5989eca91822ef5ed2"
+source = "git+https://github.com/C2SP/x509-limbo?rev=700bc657992b688f305f8f3ce08195da04543545#700bc657992b688f305f8f3ce08195da04543545"
 dependencies = [
  "chrono",
  "regress 0.11.1",
@@ -570,7 +555,6 @@ version = "0.104.0-alpha.7"
 dependencies = [
  "base64",
  "bencher",
- "bzip2",
  "chrono",
  "limbo-harness-support",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,9 +82,8 @@ untrusted = "0.9"
 [dev-dependencies]
 base64 = "0.22"
 bencher = "0.1.5"
-bzip2 = "0.6"
 chrono = "0.4"
-limbo-harness-support = { git = "https://github.com/C2SP/x509-limbo", rev = "9c7359242f16265a5154bc5989eca91822ef5ed2" }
+limbo-harness-support = { git = "https://github.com/C2SP/x509-limbo", rev = "700bc657992b688f305f8f3ce08195da04543545" }
 once_cell = "1.17.2"
 rcgen = { version = "0.14.2", default-features = false, features = ["aws_lc_rs"] }
 rustls-aws-lc-rs = { version = "0.1.0-dev.0" }

--- a/tests/x509_limbo.rs
+++ b/tests/x509_limbo.rs
@@ -3,8 +3,8 @@
 use std::collections::HashMap;
 use std::fs::File;
 
-use bzip2::read::BzDecoder;
 use chrono::{DateTime, Utc};
+use limbo_harness_support::LIMBO_JSON;
 use limbo_harness_support::models::{ExpectedResult, Feature, Limbo, Testcase, ValidationKind};
 use serde::{Deserialize, Serialize};
 
@@ -18,11 +18,7 @@ use webpki::{
 #[ignore] // Runs slower than other unit tests - opt-in with `cargo test -- --include-ignored`
 #[test]
 fn x509_limbo() {
-    let mut data_file =
-        File::open("third-party/x509-limbo/limbo.json.bz2").expect("failed to open data file");
-
-    let limbo: Limbo =
-        serde_json::from_reader(BzDecoder::new(&mut data_file)).expect("invalid test JSON");
+    let limbo: Limbo = serde_json::from_slice(LIMBO_JSON).expect("invalid test JSON");
 
     let exceptions = serde_json::from_reader(
         File::open("third-party/x509-limbo/exceptions.json")


### PR DESCRIPTION
The upstream harness support crate we take a dev git-dep on added an embedded copy of the limbo.json test data (https://github.com/C2SP/x509-limbo/pull/600), so we don't need to vendor it anymore. With both that usage and the older bettertls vendored data removed we can also drop the dev dep on bzip2.

This approach has the advantage of being easier to keep in sync with upstream, we just have to bump the Cargo.toml dev dep SHA.