### PR TITLE
doc: change tools.ietf.org references to official rfc-editor.org, use https

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -292,7 +292,7 @@ fn version3(input: &mut untrusted::Reader<'_>) -> Result<(), Error> {
 pub(crate) fn lenient_certificate_serial_number<'a>(
     input: &mut untrusted::Reader<'a>,
 ) -> Result<untrusted::Input<'a>, Error> {
-    // https://tools.ietf.org/html/rfc5280#section-4.1.2.2:
+    // https://www.rfc-editor.org/info/rfc5280/#section-4.1.2.2:
     // * Conforming CAs MUST NOT use serialNumber values longer than 20 octets."
     // * "The serial number MUST be a positive integer [...]"
     //

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -76,8 +76,8 @@ pub(crate) fn verify_dns_names(reference: &DnsName<'_>, cert: &Cert<'_>) -> Resu
 /// `<x>*<y>.<DNSID>`, where `<x>` and/or `<y>` may be empty, we follow a stricter policy common
 /// to most validation libraries (e.g. NSS) and only accept wildcard labels that are exactly `*`.
 ///
-/// [RFC 5280 Section 7.2]: https://tools.ietf.org/html/rfc5280#section-7.2
-/// [RFC 6125 Section 4.1]: https://www.rfc-editor.org/rfc/rfc6125#section-4.1
+/// [RFC 5280 Section 7.2]: https://www.rfc-editor.org/info/rfc5280/#section-7.2
+/// [RFC 6125 Section 4.1]: https://www.rfc-editor.org/info/rfc6125/#section-4.1
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
 pub(crate) struct WildcardDnsNameRef<'a>(&'a [u8]);
 
@@ -387,7 +387,7 @@ pub(super) enum IdRole {
     NameConstraint(Subtrees),
 }
 
-// https://tools.ietf.org/html/rfc5280#section-4.2.1.6:
+// https://www.rfc-editor.org/info/rfc5280/#section-4.2.1.6:
 //
 //   When the subjectAltName extension contains a domain name system
 //   label, the domain name MUST be stored in the dNSName (an IA5String).

--- a/src/subject_name/mod.rs
+++ b/src/subject_name/mod.rs
@@ -28,7 +28,7 @@ pub(crate) use dns_name::{WildcardDnsNameRef, verify_dns_names};
 mod ip_address;
 pub(crate) use ip_address::verify_ip_address_names;
 
-// https://tools.ietf.org/html/rfc5280#section-4.2.1.10
+// https://www.rfc-editor.org/info/rfc5280/#section-4.2.1.10
 pub(crate) fn check_name_constraints(
     constraints: Option<&mut untrusted::Reader<'_>>,
     path: &PathNode<'_>,
@@ -113,7 +113,7 @@ fn check_presented_id_conforms_to_constraints(
                 return Some(Err(e));
             }
 
-            // http://tools.ietf.org/html/rfc5280#section-4.2.1.10: "Within this
+            // https://www.rfc-editor.org/info/rfc5280/#section-4.2.1.10: "Within this
             // profile, the minimum and maximum fields are not used with any name
             // forms, thus, the minimum MUST be zero, and maximum MUST be absent."
             //

--- a/src/trust_anchor.rs
+++ b/src/trust_anchor.rs
@@ -55,7 +55,7 @@ pub fn spki_for_anchor(anchor: &TrustAnchor<'_>) -> SubjectPublicKeyInfoDer<'sta
 fn extract_trust_anchor_from_v1_cert_der(
     cert_der: untrusted::Input<'_>,
 ) -> Result<TrustAnchor<'_>, Error> {
-    // X.509 Certificate: https://tools.ietf.org/html/rfc5280#section-4.1.
+    // X.509 Certificate: https://www.rfc-editor.org/info/rfc5280/#section-4.1.
     cert_der.read_all(Error::BadDer, |cert_der| {
         der::nested(
             cert_der,

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -454,7 +454,7 @@ fn check_eku(
     }
 }
 
-// https://tools.ietf.org/html/rfc5280#section-4.1.2.5
+// https://www.rfc-editor.org/info/rfc5280/#section-4.1.2.5
 fn check_validity(input: &mut untrusted::Reader<'_>, time: UnixTime) -> Result<(), Error> {
     let not_before = UnixTime::from_der(input)?;
     let not_after = UnixTime::from_der(input)?;
@@ -476,7 +476,7 @@ fn check_validity(input: &mut untrusted::Reader<'_>, time: UnixTime) -> Result<(
     Ok(())
 }
 
-// https://tools.ietf.org/html/rfc5280#section-4.2.1.9
+// https://www.rfc-editor.org/info/rfc5280/#section-4.2.1.9
 fn check_basic_constraints(
     input: Option<&mut untrusted::Reader<'_>>,
     role: Role,
@@ -624,7 +624,7 @@ impl ExtendedKeyUsage {
 }
 
 impl ExtendedKeyUsageValidator for ExtendedKeyUsage {
-    // https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+    // https://www.rfc-editor.org/info/rfc5280/#section-4.2.1.12
     fn validate(&self, iter: KeyPurposeIdIter<'_, '_>) -> Result<(), Error> {
         let mut empty = true;
         #[cfg(feature = "alloc")]


### PR DESCRIPTION
The tools.ietf.org copy of RFCs was always unofficial, and the IETF would love to get rid of it.
