### PR TITLE
Enforce module import formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
           persist-credentials: false
 
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
 
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check --config imports_granularity=module
 
   clippy:
     name: Clippy

--- a/src/alg_tests.rs
+++ b/src/alg_tests.rs
@@ -17,7 +17,8 @@
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use base64::{Engine as _, engine::general_purpose};
+use base64::Engine as _;
+use base64::engine::general_purpose;
 use pki_types::alg_id;
 
 use crate::error::{DerTypeId, Error, UnsupportedSignatureAlgorithmForPublicKeyContext};

--- a/src/der.rs
+++ b/src/der.rs
@@ -16,7 +16,8 @@
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use crate::{Error, error::DerTypeId};
+use crate::Error;
+use crate::error::DerTypeId;
 
 /// Iterator to parse a sequence of DER-encoded values of type `T`.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,25 +66,23 @@ mod x509;
 #[cfg(test)]
 pub(crate) mod test_utils;
 
-pub use {
-    cert::Cert,
-    crl::{
-        BorrowedCertRevocationList, BorrowedRevokedCert, CertRevocationList, CrlsRequired,
-        ExpirationPolicy, RevocationCheckDepth, RevocationOptions, RevocationOptionsBuilder,
-        RevocationReason, UnknownStatusPolicy,
-    },
-    der::DerIterator,
-    end_entity::EndEntityCert,
-    error::{
-        DerTypeId, Error, InvalidNameContext, UnsupportedSignatureAlgorithmContext,
-        UnsupportedSignatureAlgorithmForPublicKeyContext,
-    },
-    rpk_entity::RawPublicKeyEntity,
-    trust_anchor::anchor_from_trusted_cert,
-    verify_cert::{
-        ExtendedKeyUsage, ExtendedKeyUsageValidator, IntermediateIterator, KeyPurposeId,
-        KeyPurposeIdIter, PathBuilder, RequiredEkuNotFoundContext, VerifiedPath,
-    },
+pub use cert::Cert;
+pub use crl::{
+    BorrowedCertRevocationList, BorrowedRevokedCert, CertRevocationList, CrlsRequired,
+    ExpirationPolicy, RevocationCheckDepth, RevocationOptions, RevocationOptionsBuilder,
+    RevocationReason, UnknownStatusPolicy,
+};
+pub use der::DerIterator;
+pub use end_entity::EndEntityCert;
+pub use error::{
+    DerTypeId, Error, InvalidNameContext, UnsupportedSignatureAlgorithmContext,
+    UnsupportedSignatureAlgorithmForPublicKeyContext,
+};
+pub use rpk_entity::RawPublicKeyEntity;
+pub use trust_anchor::anchor_from_trusted_cert;
+pub use verify_cert::{
+    ExtendedKeyUsage, ExtendedKeyUsageValidator, IntermediateIterator, KeyPurposeId,
+    KeyPurposeIdIter, PathBuilder, RequiredEkuNotFoundContext, VerifiedPath,
 };
 
 #[cfg(feature = "alloc")]

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -965,8 +965,7 @@ mod tests {
     use alloc::borrow::ToOwned;
     use alloc::string::{String, ToString};
     use core::time::Duration;
-    use std::dbg;
-    use std::slice;
+    use std::{dbg, slice};
 
     use super::*;
     use crate::test_utils;


### PR DESCRIPTION
I did not add it to `rustfmt.toml`, as it requires nightly toolchain. Instead, it's enforced on CI only.