### PR TITLE
crl: fix clippy::question_mark finding

### DIFF
--- a/src/crl/types.rs
+++ b/src/crl/types.rs
@@ -354,13 +354,9 @@ impl<'a> BorrowedCertRevocationList<'a> {
 
     fn find_serial(&self, serial: &[u8]) -> Result<Option<BorrowedRevokedCert<'_>>, Error> {
         for revoked_cert_result in self {
-            match revoked_cert_result {
-                Err(e) => return Err(e),
-                Ok(revoked_cert) => {
-                    if revoked_cert.serial_number.eq(serial) {
-                        return Ok(Some(revoked_cert));
-                    }
-                }
+            let revoked_cert = revoked_cert_result?;
+            if revoked_cert.serial_number.eq(serial) {
+                return Ok(Some(revoked_cert));
             }
         }
 


### PR DESCRIPTION
Fixes a failing [ci task](https://github.com/rustls/webpki/actions/runs/29041171330/job/86198413765) w/ Rust 1.97 of the form:

```
error: this `match` expression can be replaced with `?`
   --> src/crl/types.rs:357:13
    |
357 | /             match revoked_cert_result {
358 | |                 Err(e) => return Err(e),
359 | |                 Ok(revoked_cert) => {
360 | |                     if revoked_cert.serial_number.eq(serial) {
...   |
364 | |             }
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#question_mark
    = note: `-D clippy::question-mark` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::question_mark)]`
```