### PR TITLE
update x509-limbo pin for ML-DSA test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "limbo-harness-support"
 version = "0.1.0"
-source = "git+https://github.com/C2SP/x509-limbo?rev=1983423436313a6605461056470e21242d066416#1983423436313a6605461056470e21242d066416"
+source = "git+https://github.com/C2SP/x509-limbo?rev=1252c300df48507fb27e709fb287c01a9caa1e0b#1252c300df48507fb27e709fb287c01a9caa1e0b"
 dependencies = [
  "chrono",
  "regress",
@@ -809,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "typify"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0b89f47309feaeb23c4509c15c9a04234f7deccef6f96c3bfe95319819a304"
+checksum = "8cdc2e612ea322c6e232d46a0b34607c8eb28978fd6060ecfb139f2a50db8d5f"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -819,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "typify-impl"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7b026f540b148b81043c720889dbb942b08659aa8a43f624ac4f04dbfc1861"
+checksum = "691591f49550c0d371bc441d019c30ce241d4116aee7d68df7a9840d6c70bf8f"
 dependencies = [
  "heck",
  "log",
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "typify-macro"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ed96c57f06ae0839416b986921a98f18b220da63bbb243a8570a00c8492183"
+checksum = "d41aea893c49cf95661389207b8af0c6254ff48b2c3ae1e4f3704777dbdfcf03"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.24.0-dev.0"
+version = "0.24.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99552b8a20dd0e79f6c4af553583fa7e1a77acb86ef40eb3392cc7b30f373db"
+checksum = "aea97a47e031d09563e2b411eca6522d03ca605514b5f06f0fe78923d6652d28"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-aws-lc-rs"
-version = "0.1.0-dev.0"
+version = "0.1.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d021a4a49229996f6665c578895de0b95b8a20c6360852c5f5ed90644eb81c"
+checksum = "dcde4ba4d57faf984e771ccf5002c8af6fde3d0289ce741cbd8f603940efdc40"
 dependencies = [
  "aws-lc-rs",
  "rustls",
@@ -560,18 +560,29 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
-name = "rustls-ring"
-version = "0.1.0-dev.0"
+name = "rustls-post-quantum"
+version = "0.3.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc83ee09d64e1bb2c15a2b02aa78f60cb1ecb360d529876c7d6a598549fb9c9e"
+checksum = "44a0baaec20af0a8013ba19e5e6366865c97e30c4bd41cdd5de92ff7090f31d3"
+dependencies = [
+ "aws-lc-rs",
+ "rustls",
+ "rustls-aws-lc-rs",
+]
+
+[[package]]
+name = "rustls-ring"
+version = "0.1.0-dev.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2fbefa23a4c894a7e6f0ae0d23552535e064a2725f0911b05f9866e9abc658b"
 dependencies = [
  "ring",
  "rustls",
@@ -591,6 +602,7 @@ dependencies = [
  "rcgen",
  "rustls-aws-lc-rs",
  "rustls-pki-types",
+ "rustls-post-quantum",
  "rustls-ring",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ untrusted = "0.9"
 base64 = "0.22"
 bencher = "0.1.5"
 chrono = "0.4"
-limbo-harness-support = { git = "https://github.com/C2SP/x509-limbo", rev = "1983423436313a6605461056470e21242d066416" }
+limbo-harness-support = { git = "https://github.com/C2SP/x509-limbo", rev = "1252c300df48507fb27e709fb287c01a9caa1e0b" }
 once_cell = "1.17.2"
 rcgen = { version = "0.14.7", default-features = false, features = ["aws_lc_rs"] }
 rustls-aws-lc-rs = { version = "0.1.0-dev.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,8 @@ chrono = "0.4"
 limbo-harness-support = { git = "https://github.com/C2SP/x509-limbo", rev = "1983423436313a6605461056470e21242d066416" }
 once_cell = "1.17.2"
 rcgen = { version = "0.14.7", default-features = false, features = ["aws_lc_rs"] }
-rustls-aws-lc-rs = { version = "0.1.0-dev.0" }
+rustls-aws-lc-rs = { version = "0.1.0-dev.1" }
+rustls-post-quantum = { version = "0.3.0-dev.2" }
 rustls-ring = { version = "0.1.0-dev.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/tests/x509_limbo.rs
+++ b/tests/x509_limbo.rs
@@ -8,6 +8,7 @@ use limbo_harness_support::LIMBO_JSON;
 use limbo_harness_support::models::{ExpectedResult, Feature, Limbo, Testcase, ValidationKind};
 use pki_types::pem::PemObject;
 use pki_types::{CertificateDer, CertificateRevocationListDer, ServerName, UnixTime};
+use rustls_post_quantum::{ML_DSA_44, ML_DSA_65, ML_DSA_87};
 use serde::{Deserialize, Serialize};
 use webpki::{
     EndEntityCert, ExpirationPolicy, ExtendedKeyUsage, OwnedCertRevocationList, PathBuilder,
@@ -127,6 +128,9 @@ fn run_validation(tc: &Testcase) -> Result<(), String> {
         .collect::<Result<Vec<_>, _>>()?;
     let crls = crls.iter().collect::<Vec<_>>();
 
+    let mut algs = rustls_aws_lc_rs::ALL_VERIFICATION_ALGS.to_vec();
+    algs.extend_from_slice(&[ML_DSA_44, ML_DSA_65, ML_DSA_87]);
+
     let builder = PathBuilder::new(
         &intermediates,
         (!crls.is_empty()).then(|| {
@@ -138,7 +142,7 @@ fn run_validation(tc: &Testcase) -> Result<(), String> {
                 .build()
         }),
         &ExtendedKeyUsage::SERVER_AUTH,
-        rustls_aws_lc_rs::ALL_VERIFICATION_ALGS,
+        &algs,
         &trust_anchors,
     );
 

--- a/third-party/x509-limbo/exceptions.json
+++ b/third-party/x509-limbo/exceptions.json
@@ -144,6 +144,16 @@
     "actual": "SUCCESS",
     "reason": "webpki does not enforce consistency between BasicConstraints.cA and KeyUsage.keyCertSign in trust anchors"
   },
+  "rfc9881::ml-dsa-44-key-agreement": {
+    "expected": "FAILURE",
+    "actual": "SUCCESS",
+    "reason": "webpki does not enforce RFC 9881 requirement that ML-DSA certs not assert keyAgreement key usage"
+  },
+  "rfc9881::ml-dsa-44-key-encipherment": {
+    "expected": "FAILURE",
+    "actual": "SUCCESS",
+    "reason": "webpki does not enforce RFC 9881 requirement that ML-DSA certs not assert keyEncipherment key usage"
+  },
   "webpki::aki::root-with-aki-missing-keyidentifier": {
     "expected": "FAILURE",
     "actual": "SUCCESS",


### PR DESCRIPTION
Update the x509-limbo pin to pick up the new rfc9881:: testcases covering ML-DSA certificate verification (https://github.com/C2SP/x509-limbo/pull/644). Four of the six new testcases pass, the remaining two are pedantic-rfc5280 testcases expecting rejection of ML-DSA EE certs asserting keyAgreement/keyEncipherment key usage. We don't enforce that presently. This might be worth revisiting more holistically in the future, especially for new algorithms like ML-DSA.


